### PR TITLE
fix: add BlazorWebView to solution file

### DIFF
--- a/MAUI Platforms.slnx
+++ b/MAUI Platforms.slnx
@@ -16,6 +16,7 @@
     <Project Path="src\Platform.Maui.Essentials.MacOS\Platform.Maui.Essentials.MacOS.csproj" />
     <Project Path="src\Platform.Maui.Essentials.TvOS\Platform.Maui.Essentials.TvOS.csproj" />
     <Project Path="src\Platform.Maui.MacOS\Platform.Maui.MacOS.csproj" />
+    <Project Path="src\Platform.Maui.MacOS.BlazorWebView\Platform.Maui.MacOS.BlazorWebView.csproj" />
     <Project Path="src\Platform.Maui.TvOS\Platform.Maui.TvOS.csproj" />
   </Folder>
 </Solution>


### PR DESCRIPTION
The `build.slnf` filter references BlazorWebView but it was missing from the parent `MAUI Platforms.slnx`, causing CI build failure.