### PR TITLE
Add comprehensive macOS platform documentation

### DIFF
--- a/docs/macos/blazor-hybrid.md
+++ b/docs/macos/blazor-hybrid.md
@@ -1,0 +1,100 @@
+# Blazor Hybrid
+
+Host Blazor components in a native macOS WKWebView using the BlazorWebView control.
+
+## Setup
+
+### 1. Add the NuGet Package
+
+```xml
+<!-- MyApp.MacOS/MyApp.MacOS.csproj -->
+<PackageReference Include="Platform.Maui.MacOS.BlazorWebView" Version="0.2.0-beta.6" />
+```
+
+### 2. Register the Handler
+
+```csharp
+// MauiProgram.cs
+using Microsoft.Maui.Platform.MacOS.Hosting;
+
+public static MauiApp CreateMauiApp()
+{
+    var builder = MauiApp.CreateBuilder();
+    builder
+        .UseMauiAppMacOS<MacOSApp>()
+        .AddMacOSBlazorWebView();  // Register BlazorWebView handler
+
+    return builder.Build();
+}
+```
+
+### 3. Link wwwroot Resources
+
+In your macOS app head `.csproj`, link the Blazor static assets:
+
+```xml
+<ItemGroup>
+  <BundleResource Include="..\MyApp\wwwroot\**"
+                  Link="wwwroot\%(RecursiveDir)%(Filename)%(Extension)" />
+</ItemGroup>
+```
+
+The `wwwroot/` folder should contain your `index.html` and any static assets (CSS, JS, images).
+
+### 4. Use BlazorWebView in a Page
+
+```csharp
+using Microsoft.Maui.Platform.MacOS.Controls;
+
+var blazorView = new MacOSBlazorWebView
+{
+    HostPage = "wwwroot/index.html",
+};
+
+blazorView.RootComponents.Add(new RootComponent
+{
+    Selector = "#app",
+    ComponentType = typeof(MyBlazorApp.Main),
+});
+
+Content = blazorView;
+```
+
+## How It Works
+
+- **WKWebView**: Blazor components are rendered inside a native `WKWebView`
+- **Asset loading**: The `MacOSMauiAssetFileProvider` loads files from the app bundle
+- **JavaScript interop**: Full Blazor JS interop support via the WebView bridge
+- **Threading**: `MacOSBlazorDispatcher` ensures UI updates run on the main AppKit thread
+
+## Conditional Compilation
+
+If your shared project has Blazor pages that should only be available on macOS:
+
+```xml
+<!-- In your macOS .csproj -->
+<PropertyGroup>
+  <DefineConstants>$(DefineConstants);MACAPP</DefineConstants>
+</PropertyGroup>
+```
+
+```csharp
+#if MACAPP
+// Register Blazor-specific Shell routes
+shell.Items.Add(new ShellContent
+{
+    Title = "Blazor",
+    Route = "blazor",
+    ContentTemplate = new DataTemplate(typeof(BlazorPage)),
+});
+#endif
+```
+
+## Debugging with MauiDevFlow
+
+If you have [MauiDevFlow](https://github.com/nicwise/Redth.MauiDevFlow.CLI) set up, you can inspect Blazor WebView content via CDP:
+
+```bash
+maui-devflow cdp snapshot           # View DOM as accessible text
+maui-devflow cdp Runtime evaluate "document.title"  # Run JS
+```

--- a/docs/macos/controls.md
+++ b/docs/macos/controls.md
@@ -1,0 +1,141 @@
+# Controls & Platform Notes
+
+Platform-specific control behaviors, custom controls, and macOS-specific features.
+
+## App Icons
+
+The `MauiIcon` build item is automatically converted to a macOS `.icns` file at build time. No manual icon generation is needed.
+
+```xml
+<MauiIcon Include="..\MyApp\Resources\AppIcon\appicon.png" />
+```
+
+The build targets use `sips` and `iconutil` to generate all required sizes:
+
+| Size | File |
+|------|------|
+| 16×16 | `icon_16x16.png` |
+| 32×32 | `icon_16x16@2x.png`, `icon_32x32.png` |
+| 64×64 | `icon_32x32@2x.png` |
+| 128×128 | `icon_128x128.png` |
+| 256×256 | `icon_128x128@2x.png`, `icon_256x256.png` |
+| 512×512 | `icon_256x256@2x.png`, `icon_512x512.png` |
+| 1024×1024 | `icon_512x512@2x.png` |
+
+The `CFBundleIconFile` entry is automatically injected into `Info.plist`.
+
+## Modal Pages
+
+Modal pages are presented as sheet-style overlays with:
+
+- Semi-transparent backdrop (40% black)
+- `NSVisualEffectView` with `WindowBackground` material for vibrancy
+- 20px inset from safe area edges
+- 10pt rounded corners
+- Automatic light/dark mode adaptation
+
+```csharp
+await Navigation.PushModalAsync(new MyModalPage());
+await Navigation.PopModalAsync();
+```
+
+Multiple modals can be stacked — each new modal overlays the previous one.
+
+## MapView
+
+A custom `MapView` control wrapping `MKMapView`:
+
+```csharp
+using Microsoft.Maui.Platform.MacOS.Controls;
+
+var map = new MapView
+{
+    Latitude = 47.6062,
+    Longitude = -122.3321,
+    LatitudeDelta = 0.05,
+    LongitudeDelta = 0.05,
+    MapType = MapType.Standard,
+    IsScrollEnabled = true,
+    IsZoomEnabled = true,
+    IsShowingUser = true,
+};
+
+// Add overlays
+map.Pins.Add(new MapPin { Latitude = 47.6062, Longitude = -122.3321, Title = "Seattle" });
+map.Circles.Add(new MapCircle { Center = new Location(47.6, -122.3), Radius = 500 });
+map.Polylines.Add(new MapPolyline { Points = { ... } });
+map.Polygons.Add(new MapPolygon { Points = { ... } });
+```
+
+### MapType Values
+
+| Value | Description |
+|-------|-------------|
+| `Standard` | Street map |
+| `Satellite` | Satellite imagery |
+| `Hybrid` | Streets overlaid on satellite |
+
+## Gesture Recognizers
+
+All MAUI gesture recognizers are supported via `NSGestureRecognizer` wrappers:
+
+| MAUI Gesture | macOS Implementation |
+|-------------|---------------------|
+| `TapGestureRecognizer` | `NSClickGestureRecognizer` with configurable tap count |
+| `PanGestureRecognizer` | `NSPanGestureRecognizer` with velocity tracking |
+| `SwipeGestureRecognizer` | Custom four-direction swipe detection |
+| `PinchGestureRecognizer` | `NSMagnificationGestureRecognizer` |
+| `PointerGestureRecognizer` | `NSTrackingArea` for enter/exit/move events |
+
+## Coordinate System
+
+macOS AppKit uses a bottom-left origin coordinate system, but the platform automatically handles the conversion:
+
+- All `NSView` subclasses used by the platform override `IsFlipped = true` to use MAUI's top-left origin
+- Layout and hit-testing work with MAUI coordinates — no manual conversion needed
+
+## Multi-Window Support
+
+The platform supports `Application.OpenWindow()` for creating multiple windows:
+
+```csharp
+Application.Current.OpenWindow(new Window(new SecondPage()));
+```
+
+Each window gets its own toolbar state, title, and lifecycle events.
+
+## Fonts
+
+- Default system font: SF Pro Display (13pt)
+- Custom fonts registered via `MauiFont` are loaded with `CTFontManager`
+- Font weight mapping supports Bold and Light traits
+
+```csharp
+builder.ConfigureFonts(fonts =>
+{
+    fonts.AddFont("MyFont-Regular.ttf", "MyFont");
+    fonts.AddFont("MyFont-Bold.ttf", "MyFontBold");
+});
+```
+
+## Text Input
+
+- `Entry` maps to `NSTextField`
+- `Editor` maps to `NSTextView` in an `NSScrollView`
+- `SearchBar` maps to `NSSearchField`
+
+All support standard macOS text editing behaviors (spell check, auto-correct, Services menu).
+
+## Dispatcher & Threading
+
+The platform provides a main-thread dispatcher using `DispatchQueue.MainQueue`:
+
+```csharp
+MainThread.BeginInvokeOnMainThread(() =>
+{
+    // Update UI on the main thread
+    myLabel.Text = "Updated";
+});
+```
+
+Animation tickers use `NSTimer` for smooth AppKit-thread animation timing.

--- a/docs/macos/getting-started.md
+++ b/docs/macos/getting-started.md
@@ -1,0 +1,280 @@
+# Getting Started
+
+Set up a .NET MAUI macOS (AppKit) app from scratch, or add macOS support to an existing MAUI project.
+
+## Overview
+
+The macOS backend runs as a separate **app head project** that references your shared MAUI code. This is similar to how MAUI uses platform-specific head projects, but since the macOS/AppKit backend is a community package (not built into the MAUI workload), you create a standalone `net10.0-macos` project that links to your shared pages, resources, and platform code.
+
+```
+MyApp/
+├── MyApp/                      # Shared MAUI project (pages, view models, etc.)
+│   ├── Pages/
+│   ├── Resources/
+│   │   ├── Fonts/
+│   │   └── AppIcon/
+│   ├── wwwroot/                # (if using Blazor Hybrid)
+│   └── Platforms/
+│       └── macOS/              # macOS platform-specific code
+│           ├── App.cs
+│           ├── Main.cs
+│           ├── MauiMacOSApp.cs
+│           └── MauiProgram.cs
+│
+├── MyApp.MacOS/                # macOS app head project
+│   ├── MyApp.MacOS.csproj
+│   ├── Info.plist              # (optional — auto-generated if absent)
+│   └── Entitlements.plist      # (optional — for sandboxing, etc.)
+│
+└── MyApp.sln
+```
+
+## Step 1: Create the macOS App Head Project
+
+Create a new class library targeting `net10.0-macos`:
+
+```xml
+<!-- MyApp.MacOS/MyApp.MacOS.csproj -->
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-macos</TargetFramework>
+    <SupportedOSPlatformVersion>14.0</SupportedOSPlatformVersion>
+    <RootNamespace>MyApp</RootNamespace>
+
+    <!-- Prevent MAUI's default single-project processing -->
+    <UseMaui>false</UseMaui>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+  </PropertyGroup>
+
+  <!-- Platform NuGet packages -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.31" />
+    <PackageReference Include="Platform.Maui.MacOS" Version="0.2.0-beta.6" />
+  </ItemGroup>
+
+</Project>
+```
+
+> **Note:** If referencing the platform project source instead of NuGet, use `<ProjectReference>` instead of `<PackageReference>`.
+
+## Step 2: Link Shared Code
+
+Link your shared pages, view models, and helpers from the main MAUI project:
+
+```xml
+<!-- MyApp.MacOS/MyApp.MacOS.csproj -->
+<ItemGroup>
+  <!-- Platform bootstrap files -->
+  <Compile Include="..\MyApp\Platforms\macOS\App.cs" Link="App.cs" />
+  <Compile Include="..\MyApp\Platforms\macOS\Main.cs" Link="Main.cs" />
+  <Compile Include="..\MyApp\Platforms\macOS\MauiMacOSApp.cs" Link="MauiMacOSApp.cs" />
+  <Compile Include="..\MyApp\Platforms\macOS\MauiProgram.cs" Link="MauiProgram.cs" />
+
+  <!-- Shared code -->
+  <Compile Include="..\MyApp\Pages\*.cs" Link="Pages\%(Filename)%(Extension)" />
+  <Compile Include="..\MyApp\ViewModels\*.cs" Link="ViewModels\%(Filename)%(Extension)" />
+  <Compile Include="..\MyApp\Services\*.cs" Link="Services\%(Filename)%(Extension)" />
+  <!-- Add more as needed -->
+</ItemGroup>
+```
+
+### Link Resources
+
+```xml
+<ItemGroup>
+  <!-- App icon (auto-converted to .icns) -->
+  <MauiIcon Include="..\MyApp\Resources\AppIcon\appicon.png" />
+
+  <!-- Fonts -->
+  <MauiFont Include="..\MyApp\Resources\Fonts\*" />
+
+  <!-- Blazor wwwroot (if applicable) -->
+  <BundleResource Include="..\MyApp\wwwroot\**"
+                  Link="wwwroot\%(RecursiveDir)%(Filename)%(Extension)" />
+</ItemGroup>
+```
+
+### App Icon
+
+The `MauiIcon` item is automatically processed into a macOS `.icns` file at build time. The build targets use `sips` and `iconutil` to generate all required icon sizes (16×16 through 512×512 with @2x variants) from your source PNG or SVG.
+
+## Step 3: Create Platform Bootstrap Files
+
+Create these 4 files in your shared project's `Platforms/macOS/` folder.
+
+### Main.cs — Entry Point
+
+```csharp
+// Platforms/macOS/Main.cs
+using AppKit;
+
+namespace MyApp;
+
+static class MainClass
+{
+    static void Main(string[] args)
+    {
+        NSApplication.Init();
+        NSApplication.SharedApplication.Delegate = new MauiMacOSApp();
+        NSApplication.Main(args);
+    }
+}
+```
+
+### MauiMacOSApp.cs — Application Delegate
+
+```csharp
+// Platforms/macOS/MauiMacOSApp.cs
+using Foundation;
+using Microsoft.Maui.Platform.MacOS.Hosting;
+
+namespace MyApp;
+
+[Register("MauiMacOSApp")]
+public class MauiMacOSApp : MacOSMauiApplication
+{
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+}
+```
+
+### MauiProgram.cs — App Builder
+
+```csharp
+// Platforms/macOS/MauiProgram.cs
+using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Platform.MacOS.Hosting;
+
+namespace MyApp;
+
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        builder
+            .UseMauiAppMacOS<MacOSApp>()
+            .ConfigureFonts(fonts =>
+            {
+                fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
+                fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
+            });
+
+        return builder.Build();
+    }
+}
+```
+
+### App.cs — MAUI Application
+
+```csharp
+// Platforms/macOS/App.cs
+using Microsoft.Maui.Controls;
+
+namespace MyApp;
+
+public class MacOSApp : Application
+{
+    protected override Window CreateWindow(IActivationState? activationState)
+    {
+        return new Window(new MainPage());
+    }
+}
+```
+
+Or with Shell navigation:
+
+```csharp
+public class MacOSApp : Application
+{
+    protected override Window CreateWindow(IActivationState? activationState)
+    {
+        var shell = new Shell();
+
+        // Enable native macOS sidebar
+        MacOSShell.SetUseNativeSidebar(shell, true);
+
+        // Add shell items
+        var main = new ShellContent
+        {
+            Title = "Home",
+            ContentTemplate = new DataTemplate(typeof(MainPage)),
+            Route = "home"
+        };
+        shell.Items.Add(main);
+
+        return new Window(shell);
+    }
+}
+```
+
+## Step 4: Build and Run
+
+```bash
+# Build
+dotnet build MyApp.MacOS/MyApp.MacOS.csproj
+
+# The app bundle is created at:
+# MyApp.MacOS/bin/Debug/net10.0-macos/osx-arm64/MyApp.app
+
+# Launch
+open MyApp.MacOS/bin/Debug/net10.0-macos/osx-arm64/MyApp.app
+```
+
+## Conditional Compilation
+
+Use `#if` directives for macOS-specific code in shared files:
+
+```xml
+<!-- In your .csproj, define a constant -->
+<PropertyGroup>
+  <DefineConstants>$(DefineConstants);MACAPP</DefineConstants>
+</PropertyGroup>
+```
+
+```csharp
+#if MACAPP
+using Microsoft.Maui.Platform.MacOS;
+
+// macOS-specific code
+MacOSWindow.SetTitlebarStyle(window, MacOSTitlebarStyle.UnifiedCompact);
+#endif
+```
+
+## Adding Platform-Specific Handlers
+
+Register custom handlers or override existing ones in `MauiProgram.cs`:
+
+```csharp
+builder.ConfigureMauiHandlers(handlers =>
+{
+    // Use native sidebar for FlyoutPage
+    handlers.AddHandler<FlyoutPage,
+        Microsoft.Maui.Platform.MacOS.Handlers.NativeSidebarFlyoutPageHandler>();
+});
+```
+
+## Optional: Blazor Hybrid Support
+
+See [Blazor Hybrid](blazor-hybrid.md) for adding BlazorWebView support.
+
+## Optional: Essentials Support
+
+Add the Essentials package for macOS implementations of device APIs:
+
+```xml
+<PackageReference Include="Platform.Maui.Essentials.MacOS" Version="0.1.0-alpha-0001" />
+```
+
+```csharp
+// In MauiProgram.cs
+builder.AddMacOSEssentials();
+```
+
+## Tips
+
+- **SF Symbols**: Use SF Symbol names directly as `IconImageSource` values (e.g., `"gear"`, `"plus"`, `"square.and.arrow.up"`)
+- **Window size**: Set initial window size via `Window.Width` and `Window.Height` in your `App.CreateWindow()`
+- **Debug**: Use `open MyApp.app` to launch — the app runs independently of the terminal
+- **Hot reload**: Not currently supported — rebuild and relaunch for changes

--- a/docs/macos/index.md
+++ b/docs/macos/index.md
@@ -6,10 +6,16 @@ This .NET MAUI backend provides native macOS experiences using AppKit. The follo
 
 | Topic | Description |
 |-------|-------------|
+| [Getting Started](getting-started.md) | Create a macOS app head project, link shared code & resources |
 | [Sidebar Navigation](sidebar.md) | Native `NSSplitViewController` sidebar for Shell and FlyoutPage |
 | [Toolbar](toolbar.md) | NSToolbar with native item types, placement, and layout |
 | [Toolbar Item Types](toolbar-items.md) | Search, menu, segmented control, share, and popup toolbar items |
 | [Window Configuration](window.md) | Titlebar style, transparency, and toolbar style |
+| [Menu Bar](menu-bar.md) | Application menu bar and default menus |
+| [Lifecycle Events](lifecycle.md) | App and window lifecycle events |
+| [Theming](theming.md) | Light/dark mode and appearance |
+| [Blazor Hybrid](blazor-hybrid.md) | BlazorWebView with WKWebView |
+| [Controls & Platform Notes](controls.md) | MapView, gestures, modals, icons, fonts, threading |
 
 ## Quick Start
 

--- a/docs/macos/lifecycle.md
+++ b/docs/macos/lifecycle.md
@@ -1,0 +1,97 @@
+# Lifecycle Events
+
+Subscribe to macOS application lifecycle events for state management, analytics, and cleanup.
+
+## Available Events
+
+| Event | When it Fires |
+|-------|---------------|
+| `DidFinishLaunching` | App has finished launching and is ready |
+| `DidBecomeActive` | App (or a window) gained focus |
+| `DidResignActive` | App (or a window) lost focus |
+| `DidHide` | App was hidden (⌘H or Hide menu) |
+| `DidUnhide` | App was unhidden / shown again |
+| `WillTerminate` | App is about to quit |
+
+## Subscribing to Events
+
+Register lifecycle handlers in `MauiProgram.cs`:
+
+```csharp
+// MauiProgram.cs
+builder.ConfigureLifecycleEvents(events =>
+{
+    events.AddMacOS(mac =>
+    {
+        mac.DidFinishLaunching((notification) =>
+        {
+            Console.WriteLine("App launched");
+        });
+
+        mac.DidBecomeActive((notification) =>
+        {
+            Console.WriteLine("App became active");
+        });
+
+        mac.DidResignActive((notification) =>
+        {
+            Console.WriteLine("App resigned active");
+        });
+
+        mac.DidHide((notification) =>
+        {
+            Console.WriteLine("App hidden");
+        });
+
+        mac.DidUnhide((notification) =>
+        {
+            Console.WriteLine("App shown");
+        });
+
+        mac.WillTerminate((notification) =>
+        {
+            Console.WriteLine("App terminating — save state");
+        });
+    });
+});
+```
+
+## MAUI Application Lifecycle
+
+The standard MAUI `Application` lifecycle methods also work:
+
+```csharp
+public class MacOSApp : Application
+{
+    protected override Window CreateWindow(IActivationState? activationState)
+    {
+        var window = new Window(new MainPage());
+
+        window.Created += (s, e) => Console.WriteLine("Window created");
+        window.Activated += (s, e) => Console.WriteLine("Window activated");
+        window.Deactivated += (s, e) => Console.WriteLine("Window deactivated");
+        window.Stopped += (s, e) => Console.WriteLine("Window stopped");
+        window.Resumed += (s, e) => Console.WriteLine("Window resumed");
+        window.Destroying += (s, e) => Console.WriteLine("Window destroying");
+
+        return window;
+    }
+}
+```
+
+## Window Close Button
+
+When the user clicks the red close button (traffic light), the platform fires `IWindow.Destroying()` via a `MacOSWindowDelegate`. This allows you to save state or prompt the user before the window closes.
+
+## Event Flow
+
+Typical lifecycle sequence:
+
+```
+App start:    DidFinishLaunching → DidBecomeActive
+Switch away:  DidResignActive
+Switch back:  DidBecomeActive
+Hide (⌘H):   DidResignActive → DidHide
+Unhide:       DidUnhide → DidBecomeActive
+Quit (⌘Q):   DidResignActive → WillTerminate
+```

--- a/docs/macos/menu-bar.md
+++ b/docs/macos/menu-bar.md
@@ -1,0 +1,88 @@
+# Menu Bar
+
+Configure the native macOS application menu bar.
+
+## Default Menus
+
+The platform automatically creates standard macOS menus:
+
+- **App menu** — About, Preferences, Quit (with ⌘Q)
+- **Edit menu** — Undo, Redo, Cut, Copy, Paste, Delete, Select All
+- **Window menu** — Minimize, Zoom, Full Screen
+
+### Customizing Defaults
+
+Control which default menus are included via `ConfigureMacOSMenuBar()`:
+
+```csharp
+// MauiProgram.cs
+builder.ConfigureMacOSMenuBar(options =>
+{
+    options.IncludeDefaultMenus = true;       // Master toggle (default: true)
+    options.IncludeDefaultEditMenu = true;     // Edit menu (default: true)
+    options.IncludeDefaultWindowMenu = true;   // Window menu (default: true)
+});
+```
+
+Setting `IncludeDefaultMenus = false` disables all default menus. You can then build the entire menu bar from scratch using `Page.MenuBarItems`.
+
+## Page-Level Menu Items
+
+Add custom menus via `Page.MenuBarItems` on any `ContentPage`:
+
+```csharp
+public class MyPage : ContentPage
+{
+    public MyPage()
+    {
+        // Add a "File" menu
+        var fileMenu = new MenuBarItem { Text = "File" };
+
+        fileMenu.Add(new MenuFlyoutItem
+        {
+            Text = "New",
+            Command = new Command(() => CreateNew()),
+            KeyboardAccelerators =
+            {
+                new KeyboardAccelerator { Modifiers = KeyboardAcceleratorModifiers.Cmd, Key = "n" }
+            }
+        });
+
+        fileMenu.Add(new MenuFlyoutItem
+        {
+            Text = "Open...",
+            Command = new Command(() => OpenFile()),
+            KeyboardAccelerators =
+            {
+                new KeyboardAccelerator { Modifiers = KeyboardAcceleratorModifiers.Cmd, Key = "o" }
+            }
+        });
+
+        fileMenu.Add(new MenuFlyoutSeparator());
+
+        fileMenu.Add(new MenuFlyoutItem
+        {
+            Text = "Save",
+            Command = new Command(() => Save()),
+            KeyboardAccelerators =
+            {
+                new KeyboardAccelerator { Modifiers = KeyboardAcceleratorModifiers.Cmd, Key = "s" }
+            }
+        });
+
+        MenuBarItems.Add(fileMenu);
+    }
+}
+```
+
+Menu bar items are merged with the default menus. Page-level menus update automatically when the active page changes.
+
+## API Reference
+
+### MacOSMenuBarOptions
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `IncludeDefaultMenus` | `bool` | `true` | Include any default menus |
+| `IncludeDefaultEditMenu` | `bool` | `true` | Include Edit menu (Undo, Copy, Paste, etc.) |
+| `IncludeDefaultWindowMenu` | `bool` | `true` | Include Window menu (Minimize, Zoom, etc.) |

--- a/docs/macos/theming.md
+++ b/docs/macos/theming.md
@@ -1,0 +1,56 @@
+# Theming
+
+Light and dark mode support with automatic theme change detection.
+
+## Setting the App Theme
+
+Set the application theme programmatically:
+
+```csharp
+Application.Current.UserAppTheme = AppTheme.Dark;   // Force dark
+Application.Current.UserAppTheme = AppTheme.Light;   // Force light
+Application.Current.UserAppTheme = AppTheme.Unspecified; // Follow system
+```
+
+The platform maps MAUI themes to macOS appearances:
+
+| `AppTheme` | `NSAppearance` |
+|------------|----------------|
+| `Light` | `NSAppearance.NameAqua` |
+| `Dark` | `NSAppearance.NameDarkAqua` |
+| `Unspecified` | System setting (follows macOS Appearance preference) |
+
+## Responding to Theme Changes
+
+When macOS switches between light and dark mode (via System Settings or auto-schedule), the platform automatically detects the change and fires `Application.RequestedThemeChanged`:
+
+```csharp
+Application.Current.RequestedThemeChanged += (s, e) =>
+{
+    Console.WriteLine($"Theme changed to: {e.RequestedTheme}");
+};
+```
+
+### AppThemeBinding in XAML
+
+Use `AppThemeBinding` for theme-aware resources (works the same as iOS/Android):
+
+```xml
+<Label Text="Hello"
+       TextColor="{AppThemeBinding Light=Black, Dark=White}"
+       BackgroundColor="{AppThemeBinding Light=White, Dark=#1a1a1a}" />
+```
+
+### AppThemeBinding in C#
+
+```csharp
+var label = new Label { Text = "Hello" };
+label.SetAppThemeColor(Label.TextColorProperty, Colors.Black, Colors.DarkGray);
+label.SetAppThemeColor(Label.BackgroundColorProperty, Colors.White, Color.FromHex("#1a1a1a"));
+```
+
+## How It Works
+
+The platform uses `FlippedNSView.ViewDidChangeEffectiveAppearance()` to detect macOS appearance changes. When the effective appearance changes, it reads the new `NSAppearance.Name` and maps it back to `AppTheme`, then calls `Application.ThemeChanged()` to notify all MAUI bindings.
+
+The sidebar (`NSVisualEffectView`) automatically adapts to theme changes — the behind-window vibrancy material responds to light/dark mode without any additional code.


### PR DESCRIPTION
Complete documentation for all macOS platform-specific APIs in `docs/macos/`:

- **getting-started.md** — Project setup guide: app head project, linking shared code/resources, bootstrap files, build & run
- **sidebar.md** — NSSplitViewController sidebar for Shell and FlyoutPage
- **toolbar.md** — Toolbar placement, explicit layout, per-item properties
- **toolbar-items.md** — Search, menu, segmented control, share, popup item types
- **window.md** — Titlebar style, transparency, title visibility
- **menu-bar.md** — Default menus and MacOSMenuBarOptions
- **lifecycle.md** — App lifecycle events
- **theming.md** — Light/dark mode support
- **blazor-hybrid.md** — BlazorWebView setup
- **controls.md** — App icons, modals, MapView, gestures, fonts, threading
- **index.md** — Overview with links to all guides