### PR TITLE
Auto-calculate ContentInsets from toolbar height for BlazorWebView

### DIFF
--- a/samples/Sample/Pages/BlazorPage.cs
+++ b/samples/Sample/Pages/BlazorPage.cs
@@ -15,7 +15,7 @@ public class BlazorPage : ContentPage
 		var blazorWebView = new MacOSBlazorWebView
 		{
 			HostPage = "wwwroot/index.html",
-			ContentInsets = new Thickness(0, 52, 0, 0),
+			// ContentInsets are auto-calculated from toolbar height
 		};
 		blazorWebView.RootComponents.Add(new BlazorRootComponent
 		{

--- a/src/Platform.Maui.MacOS.BlazorWebView/MacOSBlazorWebView.cs
+++ b/src/Platform.Maui.MacOS.BlazorWebView/MacOSBlazorWebView.cs
@@ -20,6 +20,8 @@ public class MacOSBlazorWebView : View
     /// through the full WKWebView bounds, but scroll indicators and the initial
     /// content position are inset by these amounts.
     /// Uses WKWebView.ObscuredContentInsets (macOS 14+).
+    /// When left at default (all zeros), the top inset is automatically calculated
+    /// from the toolbar/titlebar height if the window uses FullSizeContentView.
     /// </summary>
     public static readonly BindableProperty ContentInsetsProperty =
         BindableProperty.Create(nameof(ContentInsets), typeof(Thickness), typeof(MacOSBlazorWebView), default(Thickness));
@@ -39,6 +41,8 @@ public class MacOSBlazorWebView : View
     /// <summary>
     /// Gets or sets the content insets (top, left, bottom, right) for the WebView.
     /// Content scrolls through the full bounds but is visually inset by these amounts.
+    /// When left at default (all zeros), the top inset is automatically calculated
+    /// from the toolbar/titlebar height.
     /// </summary>
     public Thickness ContentInsets
     {


### PR DESCRIPTION
## Summary

Eliminates the need for developers to hardcode magic toolbar height values when using `MacOSBlazorWebView` with `FullSizeContentView`.

## Before
```csharp
var blazorWebView = new MacOSBlazorWebView
{
    HostPage = "wwwroot/index.html",
    ContentInsets = new Thickness(0, 52, 0, 0),  // magic number!
};
```

## After
```csharp
var blazorWebView = new MacOSBlazorWebView
{
    HostPage = "wwwroot/index.html",
    // ContentInsets auto-calculated from toolbar height
};
```

## How it works

When `ContentInsets` is left at default (all zeros), the handler automatically calculates the top inset from the window's toolbar/titlebar height using:
```
window.Frame.Height - window.ContentLayoutRect.Height
```

A KVO observer defers the calculation until the WKWebView has a window, ensuring the toolbar height is available. Developers can still set explicit `ContentInsets` to override the auto behavior.

## Changes
- **`BlazorWebViewHandler`**: Refactored `MapContentInsets` to auto-calculate when insets are zero; extracted `ApplyContentInsets` helper; added `ContentInsetsWindowObserver` for deferred application
- **`MacOSBlazorWebView`**: Updated `ContentInsets` documentation to describe auto-calculation behavior
- **Sample**: Removed hardcoded `ContentInsets = new Thickness(0, 52, 0, 0)`

Fixes #26