### PR TITLE
Fix SetContentLayout(null) creating ghost Title toolbar item

### DIFF
--- a/src/Platform.Maui.MacOS/Platform/MacOSToolbarItem.cs
+++ b/src/Platform.Maui.MacOS/Platform/MacOSToolbarItem.cs
@@ -625,7 +625,7 @@ public static class MacOSToolbar
 		=> (IList<MacOSToolbarLayoutItem>?)obj.GetValue(SidebarLayoutProperty);
 
 	public static void SetSidebarLayout(BindableObject obj, IList<MacOSToolbarLayoutItem>? value)
-		=> obj.SetValue(SidebarLayoutProperty, value);
+		=> obj.SetValue(SidebarLayoutProperty, value ?? new List<MacOSToolbarLayoutItem>());
 
 	/// <summary>
 	/// When set on a <see cref="Page"/>, defines the exact layout of the content toolbar area
@@ -645,7 +645,7 @@ public static class MacOSToolbar
 		=> (IList<MacOSToolbarLayoutItem>?)obj.GetValue(ContentLayoutProperty);
 
 	public static void SetContentLayout(BindableObject obj, IList<MacOSToolbarLayoutItem>? value)
-		=> obj.SetValue(ContentLayoutProperty, value);
+		=> obj.SetValue(ContentLayoutProperty, value ?? new List<MacOSToolbarLayoutItem>());
 
 	/// <summary>
 	/// When set on a <see cref="Page"/>, adds a native <see cref="NSSearchToolbarItem"/>


### PR DESCRIPTION
## Problem

Passing `null` to `MacOSToolbar.SetContentLayout(page, null)` triggered the default convenience layout which injects `[FlexibleSpace] [Title] [FlexibleSpace]` into the toolbar. The "Title" item renders as an empty/invisible button that takes up space and intercepts clicks — a "ghost button".

## Fix

Normalize `null` to an empty list in both `SetContentLayout` and `SetSidebarLayout` setters. This makes `SetContentLayout(page, null)` equivalent to `SetContentLayout(page, new List<MacOSToolbarLayoutItem>())`, which correctly signals "explicit layout with no items" and skips the default Title injection.

The same fix is applied to `SetSidebarLayout` for consistency.

Fixes #24