### PR TITLE
Fix toolbar flash on navigation with diff-based refresh and IsVisible API

### DIFF
--- a/src/Platform.Maui.MacOS/Platform/MacOSToolbarItem.cs
+++ b/src/Platform.Maui.MacOS/Platform/MacOSToolbarItem.cs
@@ -103,6 +103,25 @@ public static class MacOSToolbarItem
 
 	public static void SetVisibilityPriority(BindableObject obj, MacOSToolbarItemVisibilityPriority value)
 		=> obj.SetValue(VisibilityPriorityProperty, value);
+
+	/// <summary>
+	/// Controls whether this toolbar item is visible. When <c>false</c>, the native
+	/// <c>NSToolbarItem.IsHidden</c> property is set to hide the item without removing
+	/// it from the toolbar — avoiding the flash/flicker caused by a full toolbar rebuild.
+	/// Defaults to <c>true</c>.
+	/// </summary>
+	public static readonly BindableProperty IsVisibleProperty =
+		BindableProperty.CreateAttached("IsVisible", typeof(bool), typeof(MacOSToolbarItem), true,
+			propertyChanged: OnIsVisibleChanged);
+
+	public static bool GetIsVisible(BindableObject obj) => (bool)obj.GetValue(IsVisibleProperty);
+	public static void SetIsVisible(BindableObject obj, bool value) => obj.SetValue(IsVisibleProperty, value);
+
+	static void OnIsVisibleChanged(BindableObject bindable, object? oldValue, object? newValue)
+	{
+		if (bindable is ToolbarItem ti && ti.Parent is Page page)
+			MacOSToolbar.RequestRefresh(page);
+	}
 }
 
 /// <summary>Identifies a built-in system toolbar item provided by AppKit.</summary>
@@ -739,4 +758,12 @@ public static class MacOSToolbar
 			}
 		}
 	}
+
+	/// <summary>
+	/// Triggers a toolbar refresh for the given page. Used by
+	/// <see cref="MacOSToolbarItem.IsVisibleProperty"/> when a ToolbarItem's
+	/// visibility changes at runtime.
+	/// </summary>
+	internal static void RequestRefresh(Page page)
+		=> OnToolbarAttachedPropertyChanged(page, null, null);
 }


### PR DESCRIPTION
## Problem

Every time toolbar items changed (page navigation, property change), `RefreshToolbar()` removed **all** `NSToolbarItem`s and re-inserted them from scratch, causing a visible flash/flicker — the single biggest visual quality issue in multi-page macOS apps.

## Changes

### 1. Diff-based refresh (Option B + C from issue)
Instead of clearing and re-inserting all items, the refresh now:
- Compares the current native item identifiers against the desired list
- Only removes/inserts items that actually changed
- Wraps all mutations in `NSAnimationContext` with `duration = 0` to suppress animation
- Skips the entire update when the identifier list hasn't changed

### 2. `MacOSToolbarItem.IsVisible` attached property (Option A from issue)
New API for showing/hiding toolbar items without any toolbar rebuild:

```csharp
// Hide a toolbar item (no flash, no rebuild)
MacOSToolbarItem.SetIsVisible(myButton, false);

// Show it again
MacOSToolbarItem.SetIsVisible(myButton, true);
```

- Maps to `NSToolbarItem.Hidden` on the native side
- Changing at runtime triggers a lightweight refresh that only syncs the Hidden state
- Applied on initial creation and synced on every refresh via `SyncItemVisibility()`

Fixes #23