### PR TITLE
Set AllowsFullHeightLayout on content split view item

### DIFF
--- a/src/Platform.Maui.MacOS/Handlers/NativeSidebarFlyoutPageHandler.cs
+++ b/src/Platform.Maui.MacOS/Handlers/NativeSidebarFlyoutPageHandler.cs
@@ -356,6 +356,7 @@ public partial class NativeSidebarFlyoutPageHandler : MacOSViewHandler<IFlyoutVi
 			_sidebarSplitItem.TitlebarSeparatorStyle = NSTitlebarSeparatorStyle.None;
 
 			var contentItem = NSSplitViewItem.CreateContentList(contentVC);
+			contentItem.AllowsFullHeightLayout = true;
 			contentItem.TitlebarSeparatorStyle = NSTitlebarSeparatorStyle.Line;
 
 			_splitViewController.AddSplitViewItem(_sidebarSplitItem);


### PR DESCRIPTION
## Problem

The content split view item in `NativeSidebarFlyoutPageHandler` was missing `AllowsFullHeightLayout = true`. This meant the BlazorWebView was positioned below the toolbar by the split view controller, rather than extending behind it.

As a result, the auto ContentInsets feature from #28 didn't produce a visible effect — `setObscuredContentInsets:` was applied to a WebView that didn't overlap the toolbar, so the scroll-behind-toolbar effect couldn't occur. Content appeared flush against the toolbar with no padding.

## Fix

Add `contentItem.AllowsFullHeightLayout = true` to match the sidebar's behavior. The content now extends behind the toolbar, and auto-insets push the initial scroll position below the toolbar correctly.

## Before / After

**Before:** Content starts flush at the toolbar boundary with no scroll-behind effect.
**After:** Content has proper toolbar-height inset and scrolls behind the toolbar with vibrancy.

## Related

- #26 / #28 — Auto ContentInsets
- #27 — HideScrollPocketOverlay