### PR TITLE
Revert AllowsFullHeightLayout on content split view item

### DIFF
--- a/src/Platform.Maui.MacOS/Handlers/NativeSidebarFlyoutPageHandler.cs
+++ b/src/Platform.Maui.MacOS/Handlers/NativeSidebarFlyoutPageHandler.cs
@@ -356,7 +356,6 @@ public partial class NativeSidebarFlyoutPageHandler : MacOSViewHandler<IFlyoutVi
 			_sidebarSplitItem.TitlebarSeparatorStyle = NSTitlebarSeparatorStyle.None;
 
 			var contentItem = NSSplitViewItem.CreateContentList(contentVC);
-			contentItem.AllowsFullHeightLayout = true;
 			contentItem.TitlebarSeparatorStyle = NSTitlebarSeparatorStyle.Line;
 
 			_splitViewController.AddSplitViewItem(_sidebarSplitItem);


### PR DESCRIPTION
Reverts #34.

Setting `AllowsFullHeightLayout = true` on the content split view item causes the WebView to extend behind the toolbar, but `setObscuredContentInsets:` doesn't properly handle scroll indicator insets in that configuration — the scrollbar renders behind the toolbar area.

The simpler approach (content positioned below toolbar by the split view + explicit `ContentInsets` for top padding within the WebView) works correctly and matches expected behavior.

The AllowsFullHeightLayout approach needs further investigation into scroll indicator inset handling before it can be used.