### PR TITLE
fix: preserve public API types in Release builds via ILLink descriptors

### DIFF
--- a/src/Platform.Maui.Essentials.MacOS/ILLink.Descriptors.xml
+++ b/src/Platform.Maui.Essentials.MacOS/ILLink.Descriptors.xml
@@ -1,0 +1,3 @@
+<linker>
+  <assembly fullname="Platform.Maui.Essentials.MacOS" preserve="all" />
+</linker>

--- a/src/Platform.Maui.Essentials.MacOS/Platform.Maui.Essentials.MacOS.csproj
+++ b/src/Platform.Maui.Essentials.MacOS/Platform.Maui.Essentials.MacOS.csproj
@@ -6,7 +6,14 @@
         <SupportedOSPlatformVersion>14.0</SupportedOSPlatformVersion>
         <PackageVersion>$(MacOSPackageVersion)</PackageVersion>
         <PackageId>Platform.Maui.MacOS.Essentials</PackageId>
+        <IsTrimmable>true</IsTrimmable>
     </PropertyGroup>
+
+    <ItemGroup>
+        <EmbeddedResource Include="ILLink.Descriptors.xml">
+            <LogicalName>ILLink.Descriptors.xml</LogicalName>
+        </EmbeddedResource>
+    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Maui.Essentials" Version="$(MauiVersion)"/>

--- a/src/Platform.Maui.MacOS.BlazorWebView/ILLink.Descriptors.xml
+++ b/src/Platform.Maui.MacOS.BlazorWebView/ILLink.Descriptors.xml
@@ -1,0 +1,3 @@
+<linker>
+  <assembly fullname="Platform.Maui.MacOS.BlazorWebView" preserve="all" />
+</linker>

--- a/src/Platform.Maui.MacOS.BlazorWebView/Platform.Maui.MacOS.BlazorWebView.csproj
+++ b/src/Platform.Maui.MacOS.BlazorWebView/Platform.Maui.MacOS.BlazorWebView.csproj
@@ -8,7 +8,14 @@
         <PackageId>Platform.Maui.MacOS.BlazorWebView</PackageId>
         <Description>Blazor Hybrid support for Platform.Maui.MacOS — host Blazor components in a native macOS AppKit window using WKWebView.</Description>
         <PackageTags>maui;macos;blazor;webview;appkit;webkit;hybrid</PackageTags>
+        <IsTrimmable>true</IsTrimmable>
     </PropertyGroup>
+
+    <ItemGroup>
+        <EmbeddedResource Include="ILLink.Descriptors.xml">
+            <LogicalName>ILLink.Descriptors.xml</LogicalName>
+        </EmbeddedResource>
+    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)"/>

--- a/src/Platform.Maui.MacOS/ILLink.Descriptors.xml
+++ b/src/Platform.Maui.MacOS/ILLink.Descriptors.xml
@@ -1,0 +1,7 @@
+<linker>
+  <!-- Preserve all public API types in the assembly.
+       These types are consumed by app projects via attached properties, XAML, or code-behind
+       and have no internal references within the library itself.
+       Without this descriptor, the trimmer strips them in Release builds. -->
+  <assembly fullname="Platform.Maui.MacOS" preserve="all" />
+</linker>

--- a/src/Platform.Maui.MacOS/Platform.Maui.MacOS.csproj
+++ b/src/Platform.Maui.MacOS/Platform.Maui.MacOS.csproj
@@ -5,10 +5,20 @@
         <RootNamespace>Microsoft.Maui.Platform.MacOS</RootNamespace>
         <SupportedOSPlatformVersion>14.0</SupportedOSPlatformVersion>
         <PackageVersion>$(MacOSPackageVersion)</PackageVersion>
+        <!-- Mark assembly as trimmer-compatible but preserve all public API types
+             via the linker descriptor (ILLink.Descriptors.xml). -->
+        <IsTrimmable>true</IsTrimmable>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)"/>
+    </ItemGroup>
+
+    <!-- Linker descriptor: preserve all public API types for AOT/trimming -->
+    <ItemGroup>
+        <EmbeddedResource Include="ILLink.Descriptors.xml">
+            <LogicalName>ILLink.Descriptors.xml</LogicalName>
+        </EmbeddedResource>
     </ItemGroup>
 
     <!-- Ship build targets with the NuGet package -->


### PR DESCRIPTION
## Problem
Release builds strip public API types like `MacOSMenuToolbarItem`, `MacOSSearchToolbarItem`, `MacOSWindow`, etc. because the ILLink trimmer sees no internal references to them — they're only consumed by app projects.

## Fix
Added embedded `ILLink.Descriptors.xml` linker descriptors to all three library projects:
- **Platform.Maui.MacOS**
- **Platform.Maui.MacOS.BlazorWebView**
- **Platform.Maui.Essentials.MacOS**

Each descriptor uses `preserve="all"` to keep the entire assembly's public surface intact.

This is the standard AOT/trimmer-friendly pattern: `IsTrimmable=true` + embedded linker descriptor, rather than disabling trimming entirely (`IsTrimmable=false`).

## Verification
- `dotnet pack -c Release` produces a DLL with all types present
- Sample app builds clean in Release mode
- Linker descriptor is embedded in the output assembly

Fixes #33