### PR TITLE
Fix TextTransform on Label and RadioButton content extraction

### DIFF
--- a/src/Platform.Maui.MacOS/Handlers/LabelHandler.cs
+++ b/src/Platform.Maui.MacOS/Handlers/LabelHandler.cs
@@ -23,6 +23,7 @@ public partial class LabelHandler : MacOSViewHandler<ILabel, MauiNSTextField>
             [nameof(Label.FormattedText)] = MapFormattedText,
             [nameof(Label.LineHeight)] = MapLineHeight,
             [nameof(Label.TextType)] = MapTextType,
+            [nameof(Label.TextTransform)] = MapTextTransform,
         };
 
     public LabelHandler() : base(Mapper)
@@ -105,6 +106,17 @@ public partial class LabelHandler : MacOSViewHandler<ILabel, MauiNSTextField>
 
         var pv = handler.PlatformView;
         var text = label.Text ?? string.Empty;
+
+        // Apply TextTransform
+        if (label is Label mauiLbl)
+        {
+            text = mauiLbl.TextTransform switch
+            {
+                TextTransform.Uppercase => text.ToUpperInvariant(),
+                TextTransform.Lowercase => text.ToLowerInvariant(),
+                _ => text,
+            };
+        }
 
         // HTML text type — parse HTML into attributed string
         if (label is Label ml2 && ml2.TextType == TextType.Html)
@@ -225,6 +237,7 @@ public partial class LabelHandler : MacOSViewHandler<ILabel, MauiNSTextField>
     public static void MapCharacterSpacing(LabelHandler handler, ILabel label) => UpdateAttributedText(handler, label);
     public static void MapTextDecorations(LabelHandler handler, ILabel label) => UpdateAttributedText(handler, label);
     public static void MapLineHeight(LabelHandler handler, ILabel label) => UpdateAttributedText(handler, label);
+    public static void MapTextTransform(LabelHandler handler, ILabel label) => UpdateAttributedText(handler, label);
 
     public static void MapHorizontalTextAlignment(LabelHandler handler, ILabel label)
     {


### PR DESCRIPTION
## Summary

Fixes two visual rendering issues discovered during the macOS vs Mac Catalyst visual comparison pass:

### Label TextTransform
- Added `TextTransform` property mapper to `LabelHandler`
- Applied Uppercase/Lowercase transforms in `UpdateAttributedText` before rendering attributed text
- Note: `ILabel` doesn't expose `TextTransform` — must cast to `Microsoft.Maui.Controls.Label`

### RadioButton Content Extraction
- Added `TextTransform` support in `MapContent` (checks `RadioButton.TextTransform`)
- Enhanced `ExtractContentText` with recursive `ExtractTextFromViewTree` method
- Handles `ContentTemplate` view hierarchies (`ILayout` children walked recursively) to find text in nested Label/Span elements
- Previously showed type names like `Microsoft.Maui.Controls.StackLayout` instead of actual text content

### Testing
Both fixes verified via side-by-side visual comparison between macOS AppKit backend and Mac Catalyst reference app using the ControlGallery sample.