### PR TITLE
Place navigation back button in content area instead of sidebar

### DIFF
--- a/src/Platform.Maui.MacOS/Handlers/ToolbarHandler.cs
+++ b/src/Platform.Maui.MacOS/Handlers/ToolbarHandler.cs
@@ -376,10 +376,6 @@ public class MacOSToolbarManager : NSObject, INSToolbarDelegate
 
         // === Build toolbar item list ===
 
-        // Sidebar area items (before tracking separator)
-        if (hasBackButton)
-            _itemIdentifiers.Add(BackButtonId);
-
         // Sidebar-placed toolbar items
         int sidebarIdx = 0;
 
@@ -488,6 +484,10 @@ public class MacOSToolbarManager : NSObject, INSToolbarDelegate
         // Tracking separator — divides sidebar area from content area
         if (_splitView != null)
             _itemIdentifiers.Add(TrackingSeparatorId);
+
+        // Back button — placed at the start of the content area (right of sidebar)
+        if (hasBackButton)
+            _itemIdentifiers.Add(BackButtonId);
 
         // Content area items (after tracking separator)
         if (hasExplicitContentLayout)


### PR DESCRIPTION
## Summary

Moves the navigation back button from the sidebar area to the content area of the toolbar.

### Before
The back button was added **before** the tracking separator, placing it inside the sidebar column — pushed as far left as possible.

### After
The back button is added **after** the tracking separator, placing it at the left edge of the content area — right next to the sidebar divider. This matches standard macOS app behavior (e.g., Finder, Mail, System Settings).

### Change
The item ordering goes from:
```
[BackButton] [sidebar items...] [TrackingSeparator] [flex] [title] [flex] [content items...]
```
to:
```
[sidebar items...] [TrackingSeparator] [BackButton] [flex] [title] [flex] [content items...]
```