### PR TITLE
Fix modal overlay not resizing with window

### DIFF
--- a/src/Platform.Maui.MacOS/Platform/MacOSModalManager.cs
+++ b/src/Platform.Maui.MacOS/Platform/MacOSModalManager.cs
@@ -67,6 +67,7 @@ internal class MacOSModalManager
 			State = NSVisualEffectState.Active,
 			BlendingMode = NSVisualEffectBlendingMode.BehindWindow,
 			WantsLayer = true,
+			AutoresizingMask = NSViewResizingMask.WidthSizable | NSViewResizingMask.HeightSizable,
 		};
 		effectView.Layer!.CornerRadius = 10;
 		effectView.Layer.MasksToBounds = true;


### PR DESCRIPTION
Adds `AutoresizingMask = NSViewResizingMask.WidthSizable | NSViewResizingMask.HeightSizable` to the modal visual effect view so it properly resizes when the window dimensions change.