### PR TITLE
feat: Native AppKit sheet modals

### DIFF
--- a/samples/Sample/Pages/NavigationDemoPage.cs
+++ b/samples/Sample/Pages/NavigationDemoPage.cs
@@ -1,5 +1,6 @@
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Platform.MacOS;
 
 namespace Sample.Pages;
 
@@ -59,35 +60,57 @@ public class NavigationDemoPage : ContentPage
 
 		var pushModalButton = new Button
 		{
-			Text = "Push Modal Page",
+			Text = "Sheet Modal (Default)",
 			Padding = new Thickness(16, 8),
 			HorizontalOptions = LayoutOptions.Start,
 		};
 		pushModalButton.Clicked += async (s, e) =>
 		{
-			var modalPage = new ContentPage
-			{
-				Title = "Modal Page",
-				Content = new VerticalStackLayout
-				{
-					Spacing = 16,
-					Padding = new Thickness(32),
-					VerticalOptions = LayoutOptions.Center,
-					HorizontalOptions = LayoutOptions.Center,
-					Children =
-					{
-						new Label { Text = "🪟 Modal Page", FontSize = 28, FontAttributes = FontAttributes.Bold, HorizontalTextAlignment = TextAlignment.Center },
-						new Label { Text = "This page was presented modally.\nIt overlays the main content.", FontSize = 14, TextColor = Colors.Gray, HorizontalTextAlignment = TextAlignment.Center },
-						new Button
-						{
-							Text = "Dismiss Modal",
-							Padding = new Thickness(16, 8),
-							Command = new Command(async () => await Navigation.PopModalAsync()),
-						}
-					}
-				}
-			};
-			await Navigation.PushModalAsync(modalPage);
+			await Navigation.PushModalAsync(CreateModalPage("Default Sheet", "Full-size native AppKit sheet.\nSlides down from the titlebar."));
+		};
+
+		var pushModalSmallButton = new Button
+		{
+			Text = "Sheet Modal (400×300)",
+			Padding = new Thickness(16, 8),
+			HorizontalOptions = LayoutOptions.Start,
+		};
+		pushModalSmallButton.Clicked += async (s, e) =>
+		{
+			var page = CreateModalPage("Small Sheet", "Custom sized sheet (400×300).\nResizable with min constraints.");
+			MacOSPage.SetModalSheetWidth(page, 400);
+			MacOSPage.SetModalSheetHeight(page, 300);
+			MacOSPage.SetModalSheetMinWidth(page, 300);
+			MacOSPage.SetModalSheetMinHeight(page, 200);
+			await Navigation.PushModalAsync(page);
+		};
+
+		var pushModalContentButton = new Button
+		{
+			Text = "Sheet Modal (Sizes to Content)",
+			Padding = new Thickness(16, 8),
+			HorizontalOptions = LayoutOptions.Start,
+		};
+		pushModalContentButton.Clicked += async (s, e) =>
+		{
+			var page = CreateModalPage("Content-Sized Sheet", "This sheet measured its content\nand sized itself to fit.");
+			MacOSPage.SetModalSheetSizesToContent(page, true);
+			MacOSPage.SetModalSheetMinWidth(page, 250);
+			MacOSPage.SetModalSheetMinHeight(page, 150);
+			await Navigation.PushModalAsync(page);
+		};
+
+		var pushModalOverlayButton = new Button
+		{
+			Text = "Overlay Modal (Old Style)",
+			Padding = new Thickness(16, 8),
+			HorizontalOptions = LayoutOptions.Start,
+		};
+		pushModalOverlayButton.Clicked += async (s, e) =>
+		{
+			var page = CreateModalPage("Overlay Modal", "Overlay presentation style.\nBackdrop + rounded effect view.");
+			MacOSPage.SetModalPresentationStyle(page, MacOSModalPresentationStyle.Overlay);
+			await Navigation.PushModalAsync(page);
 		};
 
 		var pushNoNavBarButton = new Button
@@ -142,13 +165,20 @@ public class NavigationDemoPage : ContentPage
 				pushButton,
 				popButton,
 				pushNoNavBarButton,
+
+				new Border { HeightRequest = 1, BackgroundColor = Colors.Gray, Opacity = 0.3, StrokeThickness = 0 },
+
+				new Label { Text = "Modal Presentations", FontSize = 16, FontAttributes = FontAttributes.Bold, TextColor = Colors.CornflowerBlue },
 				pushModalButton,
+				pushModalSmallButton,
+				pushModalContentButton,
+				pushModalOverlayButton,
 
 				new Border { HeightRequest = 1, BackgroundColor = Colors.Gray, Opacity = 0.3, StrokeThickness = 0 },
 
 				new Label
 				{
-					Text = "• Push/Pop tests the navigation bar with back button\n• \"No NavBar\" hides the navigation bar on the pushed page\n• \"Push Modal\" shows a modal overlay page\n• Toolbar items appear in the macOS toolbar",
+					Text = "• Push/Pop tests the navigation bar with back button\n• \"No NavBar\" hides the navigation bar on the pushed page\n• Sheet modals use native NSWindow.BeginSheet\n• Overlay modal uses the old backdrop + effect view style",
 					FontSize = 12,
 					TextColor = Colors.Gray,
 				},
@@ -164,5 +194,28 @@ public class NavigationDemoPage : ContentPage
 		4 => Colors.MediumPurple,
 		5 => Colors.Crimson,
 		_ => Colors.Teal,
+	};
+
+	ContentPage CreateModalPage(string title, string description) => new ContentPage
+	{
+		Title = title,
+		Content = new VerticalStackLayout
+		{
+			Spacing = 16,
+			Padding = new Thickness(32),
+			VerticalOptions = LayoutOptions.Center,
+			HorizontalOptions = LayoutOptions.Center,
+			Children =
+			{
+				new Label { Text = $"🪟 {title}", FontSize = 28, FontAttributes = FontAttributes.Bold, HorizontalTextAlignment = TextAlignment.Center },
+				new Label { Text = description, FontSize = 14, TextColor = Colors.Gray, HorizontalTextAlignment = TextAlignment.Center },
+				new Button
+				{
+					Text = "Dismiss Modal",
+					Padding = new Thickness(16, 8),
+					Command = new Command(async () => await Navigation.PopModalAsync()),
+				}
+			}
+		}
 	};
 }

--- a/src/Platform.Maui.MacOS/Handlers/WindowHandler.cs
+++ b/src/Platform.Maui.MacOS/Handlers/WindowHandler.cs
@@ -200,7 +200,7 @@ public partial class WindowHandler : ElementHandler<IWindow, NSWindow>
         _toolbarManager.AttachToWindow(window);
 
         // Create the modal manager
-        _modalManager = new MacOSModalManager(_contentContainer);
+        _modalManager = new MacOSModalManager(_contentContainer, window);
 
         // Set the window delegate to handle close events
         _windowDelegate = new MacOSWindowDelegate(this);
@@ -268,7 +268,7 @@ public partial class WindowHandler : ElementHandler<IWindow, NSWindow>
             // Recreate modal manager with the new content view
             var contentView = handler.PlatformView.ContentView;
             if (contentView != null)
-                handler._modalManager = new MacOSModalManager(contentView);
+                handler._modalManager = new MacOSModalManager(contentView, handler.PlatformView);
 
             handler.SubscribeModalEvents(window);
             handler.ObservePageChanges(page);

--- a/src/Platform.Maui.MacOS/Platform/MacOSModalManager.cs
+++ b/src/Platform.Maui.MacOS/Platform/MacOSModalManager.cs
@@ -8,26 +8,187 @@ namespace Microsoft.Maui.Platform.MacOS.Handlers;
 
 /// <summary>
 /// Manages modal page presentation on macOS.
-/// Modal pages are shown as overlay views on top of the window content,
-/// with a semi-transparent backdrop. This matches MAUI's cross-platform
-/// modal behavior while feeling native on macOS.
+/// By default, modals are presented as native AppKit sheets via NSWindow.BeginSheet.
+/// Pages can opt into the overlay presentation style via MacOSPage.ModalPresentationStyleProperty.
 /// </summary>
 internal class MacOSModalManager
 {
 	readonly NSView _contentContainer;
 	readonly List<ModalEntry> _modalStack = new();
+	NSWindow? _parentWindow;
 
-	record ModalEntry(Page Page, NSView BackdropView, NSView EffectView, NSView PageView, IMauiContext MauiContext);
+	record ModalEntry(
+		Page Page,
+		NSView PageView,
+		IMauiContext MauiContext,
+		MacOSModalPresentationStyle Style,
+		// Sheet mode
+		NSWindow? SheetWindow = null,
+		// Overlay mode
+		NSView? BackdropView = null,
+		NSView? EffectView = null);
 
-	public MacOSModalManager(NSView contentContainer)
+	public MacOSModalManager(NSView contentContainer, NSWindow parentWindow)
 	{
 		_contentContainer = contentContainer;
+		_parentWindow = parentWindow;
 	}
 
 	public int ModalCount => _modalStack.Count;
 	public bool HasModals => _modalStack.Count > 0;
 
+	public void UpdateParentWindow(NSWindow parentWindow)
+	{
+		_parentWindow = parentWindow;
+	}
+
 	public void PushModal(Page page, IMauiContext mauiContext, bool animated)
+	{
+		var style = MacOSPage.GetModalPresentationStyle(page);
+
+		if (style == MacOSModalPresentationStyle.Sheet)
+			PushSheet(page, mauiContext, animated);
+		else
+			PushOverlay(page, mauiContext, animated);
+	}
+
+	public Page? PopModal(bool animated)
+	{
+		if (_modalStack.Count == 0)
+			return null;
+
+		var entry = _modalStack[^1];
+		_modalStack.RemoveAt(_modalStack.Count - 1);
+
+		if (entry.Style == MacOSModalPresentationStyle.Sheet)
+			RemoveSheet(entry);
+		else
+			RemoveOverlay(entry);
+
+		return entry.Page;
+	}
+
+	public void LayoutAllModals()
+	{
+		foreach (var entry in _modalStack)
+		{
+			if (entry.Style == MacOSModalPresentationStyle.Overlay)
+				LayoutOverlay(entry);
+			// Sheet layout is managed by AppKit
+		}
+	}
+
+	#region Sheet Presentation
+
+	void PushSheet(Page page, IMauiContext mauiContext, bool animated)
+	{
+		var platformView = ((IView)page).ToMacOSPlatform(mauiContext);
+
+		if (platformView is MacOSContainerView container)
+		{
+			container.IgnorePlatformSafeArea = true;
+			container.ExternalFrameManagement = true;
+		}
+
+		var sheetSize = ComputeSheetSize(page);
+
+		var sheetFrame = new CGRect(0, 0, sheetSize.Width, sheetSize.Height);
+
+		var sheetWindow = new NSWindow(
+			sheetFrame,
+			NSWindowStyle.Titled | NSWindowStyle.Closable | NSWindowStyle.Resizable,
+			NSBackingStore.Buffered,
+			deferCreation: false);
+		sheetWindow.ReleasedWhenClosed = false;
+
+		// Apply min size constraints to the sheet window
+		var minWidth = MacOSPage.GetModalSheetMinWidth(page);
+		var minHeight = MacOSPage.GetModalSheetMinHeight(page);
+		if (minWidth > 0 || minHeight > 0)
+		{
+			sheetWindow.ContentMinSize = new CGSize(
+				minWidth > 0 ? minWidth : 0,
+				minHeight > 0 ? minHeight : 0);
+		}
+
+		platformView.Frame = new CGRect(0, 0, sheetFrame.Width, sheetFrame.Height);
+		platformView.AutoresizingMask = NSViewResizingMask.WidthSizable | NSViewResizingMask.HeightSizable;
+		sheetWindow.ContentView = platformView;
+
+		var entry = new ModalEntry(page, platformView, mauiContext, MacOSModalPresentationStyle.Sheet, SheetWindow: sheetWindow);
+		_modalStack.Add(entry);
+
+		_parentWindow?.BeginSheet(sheetWindow, (returnCode) => { });
+	}
+
+	CGSize ComputeSheetSize(Page page)
+	{
+		var parentFrame = _parentWindow?.ContentView?.Frame ?? _contentContainer.Bounds;
+		var requestedWidth = MacOSPage.GetModalSheetWidth(page);
+		var requestedHeight = MacOSPage.GetModalSheetHeight(page);
+		var sizesToContent = MacOSPage.GetModalSheetSizesToContent(page);
+
+		double width = parentFrame.Width;
+		double height = parentFrame.Height;
+
+		if (requestedWidth > 0)
+			width = requestedWidth;
+
+		if (requestedHeight > 0)
+			height = requestedHeight;
+
+		// When sizing to content, measure the page's Content (not the Page itself,
+		// since Page always fills available space). Use unconstrained dimensions
+		// so the content reports its natural/desired size.
+		if (sizesToContent && (requestedWidth <= 0 || requestedHeight <= 0))
+		{
+			var contentView = (page as ContentPage)?.Content as IView;
+			if (contentView != null)
+			{
+				var measured = contentView.Measure(
+					double.PositiveInfinity,
+					double.PositiveInfinity);
+
+				// Account for the page's own padding
+				var padding = page.Padding;
+				var contentWidth = measured.Width + padding.Left + padding.Right;
+				var contentHeight = measured.Height + padding.Top + padding.Bottom;
+
+				if (requestedWidth <= 0)
+					width = contentWidth;
+				if (requestedHeight <= 0)
+					height = contentHeight;
+			}
+		}
+
+		// Apply min size constraints
+		var minWidth = MacOSPage.GetModalSheetMinWidth(page);
+		var minHeight = MacOSPage.GetModalSheetMinHeight(page);
+		if (minWidth > 0 && width < minWidth) width = minWidth;
+		if (minHeight > 0 && height < minHeight) height = minHeight;
+
+		// Don't exceed parent window size
+		if (width > parentFrame.Width) width = parentFrame.Width;
+		if (height > parentFrame.Height) height = parentFrame.Height;
+
+		return new CGSize(width, height);
+	}
+
+	void RemoveSheet(ModalEntry entry)
+	{
+		if (entry.SheetWindow != null)
+		{
+			_parentWindow?.EndSheet(entry.SheetWindow);
+			entry.SheetWindow.OrderOut(null);
+		}
+		entry.Page.Handler?.DisconnectHandler();
+	}
+
+	#endregion
+
+	#region Overlay Presentation
+
+	void PushOverlay(Page page, IMauiContext mauiContext, bool animated)
 	{
 		// Create a semi-transparent backdrop
 		var backdrop = new NSView(_contentContainer.Bounds)
@@ -38,19 +199,15 @@ internal class MacOSModalManager
 		backdrop.Layer!.BackgroundColor = new CGColor(0, 0, 0, 0.4f);
 		_contentContainer.AddSubview(backdrop);
 
-		// Create the modal page view
 		var platformView = ((IView)page).ToMacOSPlatform(mauiContext);
 
-		// Modal pages are already positioned within safe bounds — skip safe area insets
-		// Also prevent MAUI's PlatformArrange from overriding our frame
 		if (platformView is MacOSContainerView container)
 		{
 			container.IgnorePlatformSafeArea = true;
 			container.ExternalFrameManagement = true;
 		}
 
-		// Inset from visible area to create a "sheet" appearance
-		var inset = GetModalInset();
+		var inset = GetOverlayInset();
 		var safeRect = _contentContainer.SafeAreaRect;
 
 		var pageFrame = new CGRect(
@@ -78,42 +235,23 @@ internal class MacOSModalManager
 
 		_contentContainer.AddSubview(effectView);
 
-		var entry = new ModalEntry(page, backdrop, effectView, platformView, mauiContext);
+		var entry = new ModalEntry(page, platformView, mauiContext, MacOSModalPresentationStyle.Overlay, BackdropView: backdrop, EffectView: effectView);
 		_modalStack.Add(entry);
 
-		// Measure and arrange the page
-		LayoutModal(entry);
+		LayoutOverlay(entry);
 	}
 
-	public Page? PopModal(bool animated)
-	{
-		if (_modalStack.Count == 0)
-			return null;
-
-		var entry = _modalStack[_modalStack.Count - 1];
-		_modalStack.RemoveAt(_modalStack.Count - 1);
-		RemoveModalViews(entry);
-
-		return entry.Page;
-	}
-
-	void RemoveModalViews(ModalEntry entry)
+	void RemoveOverlay(ModalEntry entry)
 	{
 		entry.PageView.RemoveFromSuperview();
-		entry.EffectView.RemoveFromSuperview();
-		entry.BackdropView.RemoveFromSuperview();
+		entry.EffectView?.RemoveFromSuperview();
+		entry.BackdropView?.RemoveFromSuperview();
 		entry.Page.Handler?.DisconnectHandler();
 	}
 
-	public void LayoutAllModals()
+	void LayoutOverlay(ModalEntry entry)
 	{
-		foreach (var entry in _modalStack)
-			LayoutModal(entry);
-	}
-
-	void LayoutModal(ModalEntry entry)
-	{
-		var inset = GetModalInset();
+		var inset = GetOverlayInset();
 		var bounds = _contentContainer.Bounds;
 		var safeRect = _contentContainer.SafeAreaRect;
 
@@ -123,8 +261,10 @@ internal class MacOSModalManager
 			safeRect.Width - inset * 2,
 			safeRect.Height - inset * 2);
 
-		entry.BackdropView.Frame = bounds;
-		entry.EffectView.Frame = pageFrame;
+		if (entry.BackdropView != null)
+			entry.BackdropView.Frame = bounds;
+		if (entry.EffectView != null)
+			entry.EffectView.Frame = pageFrame;
 		entry.PageView.Frame = new CGRect(0, 0, pageFrame.Width, pageFrame.Height);
 
 		// Trigger layout on the container — don't call page.Arrange directly
@@ -132,5 +272,7 @@ internal class MacOSModalManager
 		entry.PageView.NeedsLayout = true;
 	}
 
-	static nfloat GetModalInset() => 20;
+	static nfloat GetOverlayInset() => 20;
+
+	#endregion
 }

--- a/src/Platform.Maui.MacOS/Platform/MacOSPage.cs
+++ b/src/Platform.Maui.MacOS/Platform/MacOSPage.cs
@@ -1,0 +1,151 @@
+using Microsoft.Maui.Controls;
+
+namespace Microsoft.Maui.Platform.MacOS;
+
+/// <summary>
+/// Controls how a modal page is presented on macOS.
+/// </summary>
+public enum MacOSModalPresentationStyle
+{
+	/// <summary>
+	/// Present as a native AppKit sheet that slides down from the window titlebar.
+	/// This is the standard macOS modal presentation style.
+	/// </summary>
+	Sheet = 0,
+
+	/// <summary>
+	/// Present as an overlay view on top of the window content with a semi-transparent
+	/// backdrop and rounded corners. This is a custom MAUI presentation style.
+	/// </summary>
+	Overlay = 1,
+}
+
+/// <summary>
+/// Attached properties for configuring macOS-specific page behavior.
+/// </summary>
+/// <example>
+/// <code>
+/// // Native sheet with custom size
+/// var page = new MyModalPage();
+/// MacOSPage.SetModalSheetWidth(page, 600);
+/// MacOSPage.SetModalSheetHeight(page, 400);
+/// await Navigation.PushModalAsync(page);
+///
+/// // Sheet that sizes to its content
+/// MacOSPage.SetModalSheetSizesToContent(page, true);
+/// MacOSPage.SetModalSheetMinWidth(page, 300);
+/// MacOSPage.SetModalSheetMinHeight(page, 200);
+/// await Navigation.PushModalAsync(page);
+///
+/// // Overlay style (old behavior)
+/// MacOSPage.SetModalPresentationStyle(page, MacOSModalPresentationStyle.Overlay);
+/// await Navigation.PushModalAsync(page);
+/// </code>
+/// </example>
+public static class MacOSPage
+{
+	/// <summary>
+	/// Controls how the page is presented when pushed modally.
+	/// Defaults to <see cref="MacOSModalPresentationStyle.Sheet"/> for native AppKit sheet presentation.
+	/// Set to <see cref="MacOSModalPresentationStyle.Overlay"/> for the overlay-style presentation.
+	/// </summary>
+	public static readonly BindableProperty ModalPresentationStyleProperty =
+		BindableProperty.CreateAttached(
+			"ModalPresentationStyle",
+			typeof(MacOSModalPresentationStyle),
+			typeof(MacOSPage),
+			MacOSModalPresentationStyle.Sheet);
+
+	public static MacOSModalPresentationStyle GetModalPresentationStyle(BindableObject obj)
+		=> (MacOSModalPresentationStyle)obj.GetValue(ModalPresentationStyleProperty);
+
+	public static void SetModalPresentationStyle(BindableObject obj, MacOSModalPresentationStyle value)
+		=> obj.SetValue(ModalPresentationStyleProperty, value);
+
+	/// <summary>
+	/// When true, the sheet measures the page content and sizes to fit.
+	/// Respects <see cref="ModalSheetMinWidthProperty"/> and <see cref="ModalSheetMinHeightProperty"/>.
+	/// Ignored when <see cref="ModalSheetWidthProperty"/> or <see cref="ModalSheetHeightProperty"/> are set.
+	/// Defaults to false (sheet matches parent window size).
+	/// </summary>
+	public static readonly BindableProperty ModalSheetSizesToContentProperty =
+		BindableProperty.CreateAttached(
+			"ModalSheetSizesToContent",
+			typeof(bool),
+			typeof(MacOSPage),
+			false);
+
+	public static bool GetModalSheetSizesToContent(BindableObject obj)
+		=> (bool)obj.GetValue(ModalSheetSizesToContentProperty);
+
+	public static void SetModalSheetSizesToContent(BindableObject obj, bool value)
+		=> obj.SetValue(ModalSheetSizesToContentProperty, value);
+
+	/// <summary>
+	/// Requested width for the modal sheet. When set to -1 (default), the sheet
+	/// matches the parent window width. Only applies to Sheet presentation style.
+	/// </summary>
+	public static readonly BindableProperty ModalSheetWidthProperty =
+		BindableProperty.CreateAttached(
+			"ModalSheetWidth",
+			typeof(double),
+			typeof(MacOSPage),
+			-1d);
+
+	public static double GetModalSheetWidth(BindableObject obj)
+		=> (double)obj.GetValue(ModalSheetWidthProperty);
+
+	public static void SetModalSheetWidth(BindableObject obj, double value)
+		=> obj.SetValue(ModalSheetWidthProperty, value);
+
+	/// <summary>
+	/// Requested height for the modal sheet. When set to -1 (default), the sheet
+	/// matches the parent window height. Only applies to Sheet presentation style.
+	/// </summary>
+	public static readonly BindableProperty ModalSheetHeightProperty =
+		BindableProperty.CreateAttached(
+			"ModalSheetHeight",
+			typeof(double),
+			typeof(MacOSPage),
+			-1d);
+
+	public static double GetModalSheetHeight(BindableObject obj)
+		=> (double)obj.GetValue(ModalSheetHeightProperty);
+
+	public static void SetModalSheetHeight(BindableObject obj, double value)
+		=> obj.SetValue(ModalSheetHeightProperty, value);
+
+	/// <summary>
+	/// Minimum width for the modal sheet. Used when <see cref="ModalSheetSizesToContentProperty"/>
+	/// is true, or as the NSWindow minimum content size. Defaults to -1 (no minimum).
+	/// </summary>
+	public static readonly BindableProperty ModalSheetMinWidthProperty =
+		BindableProperty.CreateAttached(
+			"ModalSheetMinWidth",
+			typeof(double),
+			typeof(MacOSPage),
+			-1d);
+
+	public static double GetModalSheetMinWidth(BindableObject obj)
+		=> (double)obj.GetValue(ModalSheetMinWidthProperty);
+
+	public static void SetModalSheetMinWidth(BindableObject obj, double value)
+		=> obj.SetValue(ModalSheetMinWidthProperty, value);
+
+	/// <summary>
+	/// Minimum height for the modal sheet. Used when <see cref="ModalSheetSizesToContentProperty"/>
+	/// is true, or as the NSWindow minimum content size. Defaults to -1 (no minimum).
+	/// </summary>
+	public static readonly BindableProperty ModalSheetMinHeightProperty =
+		BindableProperty.CreateAttached(
+			"ModalSheetMinHeight",
+			typeof(double),
+			typeof(MacOSPage),
+			-1d);
+
+	public static double GetModalSheetMinHeight(BindableObject obj)
+		=> (double)obj.GetValue(ModalSheetMinHeightProperty);
+
+	public static void SetModalSheetMinHeight(BindableObject obj, double value)
+		=> obj.SetValue(ModalSheetMinHeightProperty, value);
+}


### PR DESCRIPTION
## Summary

Switches `PushModalAsync` to use native AppKit sheets (`NSWindow.BeginSheet`) by default, with the old overlay approach available as opt-in.

## Changes

### New: `MacOSPage` attached properties
- `ModalPresentationStyle` — `Sheet` (default) or `Overlay`
- `ModalSheetWidth` / `ModalSheetHeight` — explicit sheet size (-1 = match parent)
- `ModalSheetSizesToContent` — auto-size by measuring page content
- `ModalSheetMinWidth` / `ModalSheetMinHeight` — minimum size constraints

### Updated: `MacOSModalManager`
- Sheet path: creates `NSWindow`, uses `BeginSheet`/`EndSheet`
- Overlay path: preserved as-is (backdrop + NSVisualEffectView)
- Content measurement uses unconstrained dimensions for accurate sizing

### Sample
- NavigationDemoPage now has 4 modal demo buttons: default sheet, custom-sized sheet, content-sized sheet, and overlay

## Usage
```csharp
// Default — native sheet
await Navigation.PushModalAsync(new MyPage());

// Custom size
MacOSPage.SetModalSheetWidth(page, 600);
MacOSPage.SetModalSheetHeight(page, 400);
await Navigation.PushModalAsync(page);

// Size to content
MacOSPage.SetModalSheetSizesToContent(page, true);
await Navigation.PushModalAsync(page);

// Old overlay style
MacOSPage.SetModalPresentationStyle(page, MacOSModalPresentationStyle.Overlay);
await Navigation.PushModalAsync(page);
```