### PR TITLE
Fix controls not re-measuring after property changes

### DIFF
--- a/src/Platform.Maui.MacOS/Handlers/ButtonHandler.cs
+++ b/src/Platform.Maui.MacOS/Handlers/ButtonHandler.cs
@@ -149,7 +149,10 @@ public partial class ButtonHandler : MacOSViewHandler<IButton, NSButton>
     public static void MapText(ButtonHandler handler, IButton button)
     {
         if (button is IText textButton)
+        {
             handler.PlatformView.Title = textButton.Text ?? string.Empty;
+            handler.PlatformView.InvalidateIntrinsicContentSize();
+        }
     }
 
     public static void MapTextColor(ButtonHandler handler, IButton button)
@@ -161,7 +164,10 @@ public partial class ButtonHandler : MacOSViewHandler<IButton, NSButton>
     public static void MapFont(ButtonHandler handler, IButton button)
     {
         if (button is ITextStyle textStyle)
+        {
             handler.PlatformView.Font = textStyle.Font.ToNSFont();
+            handler.PlatformView.InvalidateIntrinsicContentSize();
+        }
     }
 
     public static void MapCharacterSpacing(ButtonHandler handler, IButton button)
@@ -184,6 +190,7 @@ public partial class ButtonHandler : MacOSViewHandler<IButton, NSButton>
                     handler.PlatformView.Font, range);
             }
             handler.PlatformView.AttributedTitle = attributedTitle;
+            handler.PlatformView.InvalidateIntrinsicContentSize();
         }
     }
 
@@ -279,6 +286,8 @@ public partial class ButtonHandler : MacOSViewHandler<IButton, NSButton>
         {
             handler.PlatformView.Image = null;
         }
+
+        handler.PlatformView.InvalidateIntrinsicContentSize();
     }
 
     static async Task LoadButtonImageFromUri(ButtonHandler handler, Uri uri)

--- a/src/Platform.Maui.MacOS/Handlers/EditorHandler.cs
+++ b/src/Platform.Maui.MacOS/Handlers/EditorHandler.cs
@@ -141,6 +141,7 @@ public class EditorHandler : MacOSViewHandler<IEditor, EditorNSView>
     public static void MapFont(EditorHandler handler, IEditor editor)
     {
         handler.PlatformView.TextView.Font = editor.Font.ToNSFont();
+        handler.PlatformView.InvalidateIntrinsicContentSize();
     }
 
     public static void MapPlaceholder(EditorHandler handler, IEditor editor)

--- a/src/Platform.Maui.MacOS/Handlers/EntryHandler.cs
+++ b/src/Platform.Maui.MacOS/Handlers/EntryHandler.cs
@@ -103,7 +103,10 @@ public partial class EntryHandler : MacOSViewHandler<IEntry, NSTextField>
     public static void MapFont(EntryHandler handler, IEntry entry)
     {
         if (entry is ITextStyle textStyle)
+        {
             handler.PlatformView.Font = textStyle.Font.ToNSFont();
+            handler.PlatformView.InvalidateIntrinsicContentSize();
+        }
     }
 
     public static void MapPlaceholder(EntryHandler handler, IEntry entry)

--- a/src/Platform.Maui.MacOS/Handlers/ImageButtonHandler.cs
+++ b/src/Platform.Maui.MacOS/Handlers/ImageButtonHandler.cs
@@ -63,6 +63,7 @@ public partial class ImageButtonHandler : MacOSViewHandler<IImageButton, NSButto
         {
             handler.PlatformView.Image = FontImageSourceHelper.CreateImage(fontSource, handler.MauiContext);
         }
+        handler.PlatformView.InvalidateIntrinsicContentSize();
     }
 
     static async Task LoadImageFromUri(ImageButtonHandler handler, Uri uri)
@@ -73,6 +74,7 @@ public partial class ImageButtonHandler : MacOSViewHandler<IImageButton, NSButto
             var data = await client.GetByteArrayAsync(uri);
             var nsImage = new NSImage(Foundation.NSData.FromArray(data));
             handler.PlatformView.Image = nsImage;
+            handler.PlatformView.InvalidateIntrinsicContentSize();
         }
         catch
         {

--- a/src/Platform.Maui.MacOS/Handlers/ImageHandler.cs
+++ b/src/Platform.Maui.MacOS/Handlers/ImageHandler.cs
@@ -71,6 +71,7 @@ public partial class ImageHandler : MacOSViewHandler<IImage, NSImageView>
         if (source == null)
         {
             PlatformView.Image = null;
+            PlatformView.InvalidateIntrinsicContentSize();
             imageSourcePart.UpdateIsLoading(false);
             return;
         }
@@ -86,6 +87,7 @@ public partial class ImageHandler : MacOSViewHandler<IImage, NSImageView>
                 PlatformView.Image = nsImage;
             }
 
+            PlatformView.InvalidateIntrinsicContentSize();
             imageSourcePart.UpdateIsLoading(false);
         }
         else if (source is IUriImageSource uriImageSource)
@@ -98,6 +100,7 @@ public partial class ImageHandler : MacOSViewHandler<IImage, NSImageView>
             else
             {
                 PlatformView.Image = null;
+                PlatformView.InvalidateIntrinsicContentSize();
                 imageSourcePart.UpdateIsLoading(false);
             }
         }
@@ -112,6 +115,7 @@ public partial class ImageHandler : MacOSViewHandler<IImage, NSImageView>
         else
         {
             PlatformView.Image = null;
+            PlatformView.InvalidateIntrinsicContentSize();
             imageSourcePart.UpdateIsLoading(false);
         }
     }
@@ -190,7 +194,10 @@ public partial class ImageHandler : MacOSViewHandler<IImage, NSImageView>
             var nsImage = new NSImage(nsData);
 
             if (PlatformView != null)
+            {
                 PlatformView.Image = nsImage;
+                PlatformView.InvalidateIntrinsicContentSize();
+            }
         }
         catch (Exception ex)
         {
@@ -215,7 +222,10 @@ public partial class ImageHandler : MacOSViewHandler<IImage, NSImageView>
                 var nsImage = new NSImage(nsData);
 
                 if (PlatformView != null)
+                {
                     PlatformView.Image = nsImage;
+                    PlatformView.InvalidateIntrinsicContentSize();
+                }
 
                 stream.Dispose();
             }
@@ -234,6 +244,7 @@ public partial class ImageHandler : MacOSViewHandler<IImage, NSImageView>
     {
         var image = FontImageSourceHelper.CreateImage(fontImageSource, MauiContext);
         PlatformView.Image = image;
+        PlatformView.InvalidateIntrinsicContentSize();
         imageSourcePart.UpdateIsLoading(false);
     }
 }

--- a/src/Platform.Maui.MacOS/Handlers/LabelHandler.cs
+++ b/src/Platform.Maui.MacOS/Handlers/LabelHandler.cs
@@ -169,6 +169,7 @@ public partial class LabelHandler : MacOSViewHandler<ILabel, MauiNSTextField>
         attrs[NSStringAttributeKey.ParagraphStyle] = paraStyle;
 
         pv.AttributedStringValue = new NSAttributedString(text, attrs);
+        pv.InvalidateIntrinsicContentSize();
     }
 
     static void UpdateHtmlText(LabelHandler handler, ILabel label, string html)
@@ -228,6 +229,7 @@ public partial class LabelHandler : MacOSViewHandler<ILabel, MauiNSTextField>
             // Fallback to plain text if HTML parsing fails
             pv.StringValue = html;
         }
+        pv.InvalidateIntrinsicContentSize();
     }
 
     public static void MapText(LabelHandler handler, ILabel label) => UpdateAttributedText(handler, label);
@@ -264,12 +266,14 @@ public partial class LabelHandler : MacOSViewHandler<ILabel, MauiNSTextField>
             LineBreakMode.MiddleTruncation => NSLineBreakMode.TruncatingMiddle,
             _ => NSLineBreakMode.ByWordWrapping,
         };
+        handler.PlatformView.InvalidateIntrinsicContentSize();
     }
 
     public static void MapMaxLines(LabelHandler handler, ILabel label)
     {
         if (label is Label mauiLabel)
             handler.PlatformView.MaximumNumberOfLines = mauiLabel.MaxLines;
+        handler.PlatformView.InvalidateIntrinsicContentSize();
     }
 
     public static void MapPadding(LabelHandler handler, ILabel label)
@@ -278,6 +282,7 @@ public partial class LabelHandler : MacOSViewHandler<ILabel, MauiNSTextField>
         handler.PlatformView.TextInsets = new AppKit.NSEdgeInsets(
             (nfloat)padding.Top, (nfloat)padding.Left,
             (nfloat)padding.Bottom, (nfloat)padding.Right);
+        handler.PlatformView.InvalidateIntrinsicContentSize();
     }
 
     public static void MapFormattedText(LabelHandler handler, ILabel label)
@@ -336,8 +341,8 @@ public partial class LabelHandler : MacOSViewHandler<ILabel, MauiNSTextField>
         }
 
         handler.PlatformView.AttributedStringValue = attributed;
+        handler.PlatformView.InvalidateIntrinsicContentSize();
     }
-
     static NSFont SpanToNSFont(Span span)
     {
         var size = span.FontSize > 0 ? (nfloat)span.FontSize : (nfloat)13.0;

--- a/src/Platform.Maui.MacOS/Handlers/RadioButtonHandler.cs
+++ b/src/Platform.Maui.MacOS/Handlers/RadioButtonHandler.cs
@@ -88,6 +88,7 @@ public partial class RadioButtonHandler : MacOSViewHandler<IRadioButton, NSButto
 		}
 
 		handler.PlatformView.Title = text;
+		handler.PlatformView.InvalidateIntrinsicContentSize();
 	}
 
 	static string? ExtractContentText(IRadioButton view)


### PR DESCRIPTION
Fixes #46

## Problem
Handler Map methods that change size-affecting properties (Text, Font, Image, CharacterSpacing, Padding, MaxLines, LineBreakMode, FormattedText) were not calling `InvalidateIntrinsicContentSize()` on the native NSView. This caused controls to retain their original measured size when properties changed at runtime.

## Fix
Added `InvalidateIntrinsicContentSize()` calls after every property change that affects intrinsic size across 7 handlers:

- **ButtonHandler** — MapText, MapFont, MapCharacterSpacing, MapImageSource
- **LabelHandler** — UpdateAttributedText, UpdateHtmlText, MapMaxLines, MapLineBreakMode, MapPadding, MapFormattedText
- **EntryHandler** — MapFont
- **EditorHandler** — MapFont
- **RadioButtonHandler** — MapContent
- **ImageHandler** — LoadImageSource (all branches), LoadFromUri, LoadFromStream, LoadFromFontGlyph
- **ImageButtonHandler** — MapSource, LoadImageFromUri