### PR TITLE
Fix ContentPresenter crash with NotImplementedException

### DIFF
--- a/src/Platform.Maui.MacOS/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Platform.Maui.MacOS/Hosting/AppHostBuilderExtensions.cs
@@ -29,6 +29,7 @@ public static partial class AppHostBuilderExtensions
         handlersCollection.AddHandler<ContentPage, ContentPageHandler>();
         handlersCollection.AddHandler<Layout, LayoutHandler>();
         handlersCollection.AddHandler<ContentView, ContentViewHandler>();
+        handlersCollection.AddHandler<ContentPresenter, ContentViewHandler>();
         handlersCollection.AddHandler<Label, LabelHandler>();
         handlersCollection.AddHandler<Button, ButtonHandler>();
         handlersCollection.AddHandler<Entry, EntryHandler>();


### PR DESCRIPTION
Fixes #51

## Problem
Using a `ContentView` with a `ControlTemplate` containing a `ContentPresenter` crashes with `NotImplementedException` because `ContentPresenter` had no macOS handler registered — it fell through to the default MAUI `ContentViewHandler` stub.

## Fix
One-line fix: register `ContentPresenter` with the same `ContentViewHandler` used for `ContentView`. Since `ContentPresenter` extends `ContentView`, the same handler works correctly.