### PR TITLE
feat: Nested modal stacking and Window modal presentation style

### DIFF
--- a/samples/ControlGallery/AppShell.xaml.cs
+++ b/samples/ControlGallery/AppShell.xaml.cs
@@ -6,6 +6,7 @@ using CommunityToolkit.Mvvm.Messaging;
 using ControlGallery.Common.Messages;
 using ControlGallery.Pages;
 using ControlGallery.Pages.Controls.CarouselView;
+using ControlGallery.Pages.Features;
 using ControlGallery.Pages.Features.Animation;
 using ControlGallery.Pages.Layouts;
 using ControlGallery.Pages.Layouts.AbsoluteLayouts;
@@ -226,6 +227,7 @@ public partial class AppShell : Shell
         Routing.RegisterRoute(nameof(REIPage), typeof(REIPage));
 
         Routing.RegisterRoute(nameof(HybridWebViewPage), typeof(HybridWebViewPage));
+        Routing.RegisterRoute(nameof(ModalStackingPage), typeof(ModalStackingPage));
 
         Routing.RegisterRoute(nameof(AchievementsPage), typeof(AchievementsPage));
         Routing.RegisterRoute(nameof(AlignmentPage), typeof(AlignmentPage));

--- a/samples/ControlGallery/Pages/Features/ModalStackingPage.cs
+++ b/samples/ControlGallery/Pages/Features/ModalStackingPage.cs
@@ -1,0 +1,123 @@
+using Microsoft.Maui.Platform.MacOS;
+
+namespace ControlGallery.Pages.Features;
+
+public class ModalStackingPage : ContentPageBase
+{
+	protected override void Build()
+	{
+		Title = "Modal Stacking";
+
+		Content = new ScrollView
+		{
+			Content = new VerticalStackLayout
+			{
+				Padding = 20,
+				Spacing = 16,
+				Children =
+				{
+					new Label
+					{
+						Text = "Nested Modal Sheets",
+						FontSize = 24,
+						FontAttributes = FontAttributes.Bold,
+					},
+					new Label
+					{
+						Text = "Each button pushes a modal sheet. Sheets stack on top of each other using native AppKit sheet-on-sheet presentation.",
+					},
+					CreateButton("Push Sheet Modal", MacOSModalPresentationStyle.Sheet),
+					CreateButton("Push Overlay Modal", MacOSModalPresentationStyle.Overlay),
+					CreateButton("Push Window Modal", MacOSModalPresentationStyle.Window),
+				}
+			}
+		};
+	}
+
+	Button CreateButton(string text, MacOSModalPresentationStyle style)
+	{
+		var btn = new Button { Text = text };
+		btn.Clicked += async (s, e) =>
+		{
+			var page = CreateModalPage(1, style);
+			await Navigation.PushModalAsync(page);
+		};
+		return btn;
+	}
+
+	static ContentPage CreateModalPage(int depth, MacOSModalPresentationStyle style)
+	{
+		var page = new ContentPage { Title = $"Modal #{depth}" };
+
+		MacOSPage.SetModalPresentationStyle(page, style);
+		MacOSPage.SetModalSheetWidth(page, Math.Max(300, 500 - (depth - 1) * 40));
+		MacOSPage.SetModalSheetHeight(page, Math.Max(250, 400 - (depth - 1) * 30));
+		MacOSPage.SetModalSheetMinWidth(page, 250);
+		MacOSPage.SetModalSheetMinHeight(page, 200);
+
+		var depthLabel = new Label
+		{
+			Text = $"Sheet Depth: {depth}",
+			FontSize = 20,
+			FontAttributes = FontAttributes.Bold,
+			HorizontalOptions = LayoutOptions.Center,
+		};
+
+		var styleLabel = new Label
+		{
+			Text = $"Style: {style}",
+			HorizontalOptions = LayoutOptions.Center,
+			TextColor = Colors.Gray,
+		};
+
+		var pushSheetBtn = new Button { Text = $"Push Sheet #{depth + 1}" };
+		pushSheetBtn.Clicked += async (s, e) =>
+		{
+			var next = CreateModalPage(depth + 1, MacOSModalPresentationStyle.Sheet);
+			await page.Navigation.PushModalAsync(next);
+		};
+
+		var pushOverlayBtn = new Button { Text = $"Push Overlay #{depth + 1}" };
+		pushOverlayBtn.Clicked += async (s, e) =>
+		{
+			var next = CreateModalPage(depth + 1, MacOSModalPresentationStyle.Overlay);
+			await page.Navigation.PushModalAsync(next);
+		};
+
+		var pushWindowBtn = new Button { Text = $"Push Window #{depth + 1}" };
+		pushWindowBtn.Clicked += async (s, e) =>
+		{
+			var next = CreateModalPage(depth + 1, MacOSModalPresentationStyle.Window);
+			await page.Navigation.PushModalAsync(next);
+		};
+
+		var dismissBtn = new Button
+		{
+			Text = "Dismiss",
+			BackgroundColor = Colors.OrangeRed,
+			TextColor = Colors.White,
+		};
+		dismissBtn.Clicked += async (s, e) =>
+		{
+			await page.Navigation.PopModalAsync();
+		};
+
+		page.Content = new VerticalStackLayout
+		{
+			Padding = 20,
+			Spacing = 12,
+			VerticalOptions = LayoutOptions.Center,
+			Children =
+			{
+				depthLabel,
+				styleLabel,
+				pushSheetBtn,
+				pushOverlayBtn,
+				pushWindowBtn,
+				dismissBtn,
+			}
+		};
+
+		return page;
+	}
+}

--- a/samples/ControlGallery/Pages/FeaturesPage.xaml
+++ b/samples/ControlGallery/Pages/FeaturesPage.xaml
@@ -38,6 +38,8 @@
                                    Destination="{x:Type TriggersPage}"/>
                             <NavItem Title="HybridWebView"
                                    Destination="{x:Type HybridWebViewPage}"/>
+                            <NavItem Title="Modal Stacking"
+                                   Destination="{x:Type ModalStackingPage}"/>
 
                             
 

--- a/samples/Sample/Pages/NavigationDemoPage.cs
+++ b/samples/Sample/Pages/NavigationDemoPage.cs
@@ -113,6 +113,30 @@ public class NavigationDemoPage : ContentPage
 			await Navigation.PushModalAsync(page);
 		};
 
+		var pushModalWindowButton = new Button
+		{
+			Text = "Window Modal",
+			Padding = new Thickness(16, 8),
+			HorizontalOptions = LayoutOptions.Start,
+		};
+		pushModalWindowButton.Clicked += async (s, e) =>
+		{
+			var page = CreateStackableModalPage(1, MacOSModalPresentationStyle.Window);
+			await Navigation.PushModalAsync(page);
+		};
+
+		var pushStackedSheetButton = new Button
+		{
+			Text = "Stacked Sheets (Nested)",
+			Padding = new Thickness(16, 8),
+			HorizontalOptions = LayoutOptions.Start,
+		};
+		pushStackedSheetButton.Clicked += async (s, e) =>
+		{
+			var page = CreateStackableModalPage(1, MacOSModalPresentationStyle.Sheet);
+			await Navigation.PushModalAsync(page);
+		};
+
 		var pushNoNavBarButton = new Button
 		{
 			Text = "Push Page (No NavBar)",
@@ -173,12 +197,14 @@ public class NavigationDemoPage : ContentPage
 				pushModalSmallButton,
 				pushModalContentButton,
 				pushModalOverlayButton,
+				pushModalWindowButton,
+				pushStackedSheetButton,
 
 				new Border { HeightRequest = 1, BackgroundColor = Colors.Gray, Opacity = 0.3, StrokeThickness = 0 },
 
 				new Label
 				{
-					Text = "• Push/Pop tests the navigation bar with back button\n• \"No NavBar\" hides the navigation bar on the pushed page\n• Sheet modals use native NSWindow.BeginSheet\n• Overlay modal uses the old backdrop + effect view style",
+					Text = "• Push/Pop tests the navigation bar with back button\n• \"No NavBar\" hides the navigation bar on the pushed page\n• Sheet modals use native NSWindow.BeginSheet\n• Overlay modal uses the old backdrop + effect view style\n• Window modal uses a child NSWindow that blocks the parent\n• Stacked sheets nest sheet-on-sheet with push buttons inside each modal",
 					FontSize = 12,
 					TextColor = Colors.Gray,
 				},
@@ -218,4 +244,79 @@ public class NavigationDemoPage : ContentPage
 			}
 		}
 	};
+
+	ContentPage CreateStackableModalPage(int depth, MacOSModalPresentationStyle style)
+	{
+		var page = new ContentPage { Title = $"Modal #{depth} ({style})" };
+
+		MacOSPage.SetModalPresentationStyle(page, style);
+		MacOSPage.SetModalSheetWidth(page, Math.Max(300, 500 - (depth - 1) * 40));
+		MacOSPage.SetModalSheetHeight(page, Math.Max(250, 400 - (depth - 1) * 30));
+		MacOSPage.SetModalSheetMinWidth(page, 250);
+		MacOSPage.SetModalSheetMinHeight(page, 200);
+
+		var pushSheetBtn = new Button
+		{
+			Text = $"Push Sheet #{depth + 1}",
+			Padding = new Thickness(16, 8),
+		};
+		pushSheetBtn.Clicked += async (s, e) =>
+		{
+			var next = CreateStackableModalPage(depth + 1, MacOSModalPresentationStyle.Sheet);
+			await page.Navigation.PushModalAsync(next);
+		};
+
+		var pushWindowBtn = new Button
+		{
+			Text = $"Push Window #{depth + 1}",
+			Padding = new Thickness(16, 8),
+		};
+		pushWindowBtn.Clicked += async (s, e) =>
+		{
+			var next = CreateStackableModalPage(depth + 1, MacOSModalPresentationStyle.Window);
+			await page.Navigation.PushModalAsync(next);
+		};
+
+		var dismissBtn = new Button
+		{
+			Text = "Dismiss",
+			Padding = new Thickness(16, 8),
+			BackgroundColor = Colors.OrangeRed,
+			TextColor = Colors.White,
+		};
+		dismissBtn.Clicked += async (s, e) =>
+		{
+			await page.Navigation.PopModalAsync();
+		};
+
+		page.Content = new VerticalStackLayout
+		{
+			Spacing = 12,
+			Padding = new Thickness(24),
+			VerticalOptions = LayoutOptions.Center,
+			HorizontalOptions = LayoutOptions.Center,
+			Children =
+			{
+				new Label
+				{
+					Text = $"Modal #{depth}",
+					FontSize = 24,
+					FontAttributes = FontAttributes.Bold,
+					HorizontalTextAlignment = TextAlignment.Center,
+				},
+				new Label
+				{
+					Text = $"Style: {style}",
+					FontSize = 14,
+					TextColor = Colors.Gray,
+					HorizontalTextAlignment = TextAlignment.Center,
+				},
+				pushSheetBtn,
+				pushWindowBtn,
+				dismissBtn,
+			}
+		};
+
+		return page;
+	}
 }

--- a/src/Platform.Maui.MacOS/Platform/MacOSModalManager.cs
+++ b/src/Platform.Maui.MacOS/Platform/MacOSModalManager.cs
@@ -22,11 +22,15 @@ internal class MacOSModalManager
 		NSView PageView,
 		IMauiContext MauiContext,
 		MacOSModalPresentationStyle Style,
-		// Sheet mode
-		NSWindow? SheetWindow = null,
+		// Sheet and Window modes: the NSWindow hosting the modal content
+		NSWindow? ModalWindow = null,
+		// Sheet and Window modes: the window that presented this modal
+		NSWindow? PresentingWindow = null,
 		// Overlay mode
 		NSView? BackdropView = null,
-		NSView? EffectView = null);
+		NSView? EffectView = null,
+		// Window mode: dims and blocks interaction on the presenting window
+		NSView? HostBlockerView = null);
 
 	public MacOSModalManager(NSView contentContainer, NSWindow parentWindow)
 	{
@@ -42,14 +46,37 @@ internal class MacOSModalManager
 		_parentWindow = parentWindow;
 	}
 
+	/// <summary>
+	/// Returns the topmost modal NSWindow (sheet or window-modal) if one exists,
+	/// otherwise the parent window. This enables nesting: each new modal is
+	/// presented from the topmost existing modal rather than always from the parent.
+	/// </summary>
+	NSWindow? GetTopmostModalHost()
+	{
+		for (int i = _modalStack.Count - 1; i >= 0; i--)
+		{
+			if (_modalStack[i].ModalWindow is { } win)
+				return win;
+		}
+		return _parentWindow;
+	}
+
 	public void PushModal(Page page, IMauiContext mauiContext, bool animated)
 	{
 		var style = MacOSPage.GetModalPresentationStyle(page);
 
-		if (style == MacOSModalPresentationStyle.Sheet)
-			PushSheet(page, mauiContext, animated);
-		else
-			PushOverlay(page, mauiContext, animated);
+		switch (style)
+		{
+			case MacOSModalPresentationStyle.Sheet:
+				PushSheet(page, mauiContext, animated);
+				break;
+			case MacOSModalPresentationStyle.Window:
+				PushModalWindow(page, mauiContext, animated);
+				break;
+			default:
+				PushOverlay(page, mauiContext, animated);
+				break;
+		}
 	}
 
 	public Page? PopModal(bool animated)
@@ -60,10 +87,18 @@ internal class MacOSModalManager
 		var entry = _modalStack[^1];
 		_modalStack.RemoveAt(_modalStack.Count - 1);
 
-		if (entry.Style == MacOSModalPresentationStyle.Sheet)
-			RemoveSheet(entry);
-		else
-			RemoveOverlay(entry);
+		switch (entry.Style)
+		{
+			case MacOSModalPresentationStyle.Sheet:
+				RemoveSheet(entry);
+				break;
+			case MacOSModalPresentationStyle.Window:
+				RemoveModalWindow(entry);
+				break;
+			default:
+				RemoveOverlay(entry);
+				break;
+		}
 
 		return entry.Page;
 	}
@@ -115,10 +150,12 @@ internal class MacOSModalManager
 		platformView.AutoresizingMask = NSViewResizingMask.WidthSizable | NSViewResizingMask.HeightSizable;
 		sheetWindow.ContentView = platformView;
 
-		var entry = new ModalEntry(page, platformView, mauiContext, MacOSModalPresentationStyle.Sheet, SheetWindow: sheetWindow);
+		var presentingWindow = GetTopmostModalHost();
+
+		var entry = new ModalEntry(page, platformView, mauiContext, MacOSModalPresentationStyle.Sheet, ModalWindow: sheetWindow, PresentingWindow: presentingWindow);
 		_modalStack.Add(entry);
 
-		_parentWindow?.BeginSheet(sheetWindow, (returnCode) => { });
+		presentingWindow?.BeginSheet(sheetWindow, (returnCode) => { });
 	}
 
 	CGSize ComputeSheetSize(Page page)
@@ -176,12 +213,101 @@ internal class MacOSModalManager
 
 	void RemoveSheet(ModalEntry entry)
 	{
-		if (entry.SheetWindow != null)
+		if (entry.ModalWindow != null)
 		{
-			_parentWindow?.EndSheet(entry.SheetWindow);
-			entry.SheetWindow.OrderOut(null);
+			var host = entry.PresentingWindow ?? _parentWindow;
+			host?.EndSheet(entry.ModalWindow);
+			entry.ModalWindow.OrderOut(null);
 		}
 		entry.Page.Handler?.DisconnectHandler();
+	}
+
+	#endregion
+
+	#region Window Modal Presentation
+
+	void PushModalWindow(Page page, IMauiContext mauiContext, bool animated)
+	{
+		var platformView = ((IView)page).ToMacOSPlatform(mauiContext);
+
+		if (platformView is MacOSContainerView container)
+		{
+			container.IgnorePlatformSafeArea = true;
+			container.ExternalFrameManagement = true;
+		}
+
+		var hostWindow = GetTopmostModalHost();
+
+		// Add a dimming overlay to the host window to block interaction
+		NSView? blockerView = null;
+		if (hostWindow?.ContentView is { } hostContent)
+		{
+			blockerView = new NSView(hostContent.Bounds)
+			{
+				WantsLayer = true,
+				AutoresizingMask = NSViewResizingMask.WidthSizable | NSViewResizingMask.HeightSizable,
+			};
+			blockerView.Layer!.BackgroundColor = new CGColor(0, 0, 0, 0.25f);
+			hostContent.AddSubview(blockerView);
+		}
+
+		var modalSize = ComputeSheetSize(page);
+		var modalFrame = ComputeCenteredFrame(hostWindow, modalSize);
+
+		var modalWindow = new NSWindow(
+			modalFrame,
+			NSWindowStyle.Titled | NSWindowStyle.Resizable,
+			NSBackingStore.Buffered,
+			deferCreation: false);
+		modalWindow.ReleasedWhenClosed = false;
+
+		var minWidth = MacOSPage.GetModalSheetMinWidth(page);
+		var minHeight = MacOSPage.GetModalSheetMinHeight(page);
+		if (minWidth > 0 || minHeight > 0)
+		{
+			modalWindow.ContentMinSize = new CGSize(
+				minWidth > 0 ? minWidth : 0,
+				minHeight > 0 ? minHeight : 0);
+		}
+
+		platformView.Frame = new CGRect(0, 0, modalSize.Width, modalSize.Height);
+		platformView.AutoresizingMask = NSViewResizingMask.WidthSizable | NSViewResizingMask.HeightSizable;
+		modalWindow.ContentView = platformView;
+
+		hostWindow?.AddChildWindow(modalWindow, NSWindowOrderingMode.Above);
+		modalWindow.MakeKeyAndOrderFront(null);
+
+		var entry = new ModalEntry(page, platformView, mauiContext, MacOSModalPresentationStyle.Window,
+			ModalWindow: modalWindow, PresentingWindow: hostWindow, HostBlockerView: blockerView);
+		_modalStack.Add(entry);
+	}
+
+	void RemoveModalWindow(ModalEntry entry)
+	{
+		// Remove the blocker overlay from the host window
+		entry.HostBlockerView?.RemoveFromSuperview();
+
+		if (entry.ModalWindow != null)
+		{
+			entry.PresentingWindow?.RemoveChildWindow(entry.ModalWindow);
+			entry.ModalWindow.OrderOut(null);
+		}
+
+		// Re-activate the host window
+		entry.PresentingWindow?.MakeKeyAndOrderFront(null);
+
+		entry.Page.Handler?.DisconnectHandler();
+	}
+
+	static CGRect ComputeCenteredFrame(NSWindow? host, CGSize size)
+	{
+		if (host == null)
+			return new CGRect(100, 100, size.Width, size.Height);
+
+		var hostFrame = host.Frame;
+		var x = hostFrame.X + (hostFrame.Width - size.Width) / 2;
+		var y = hostFrame.Y + (hostFrame.Height - size.Height) / 2;
+		return new CGRect(x, y, size.Width, size.Height);
 	}
 
 	#endregion

--- a/src/Platform.Maui.MacOS/Platform/MacOSPage.cs
+++ b/src/Platform.Maui.MacOS/Platform/MacOSPage.cs
@@ -18,6 +18,13 @@ public enum MacOSModalPresentationStyle
 	/// backdrop and rounded corners. This is a custom MAUI presentation style.
 	/// </summary>
 	Overlay = 1,
+
+	/// <summary>
+	/// Present as a separate floating NSWindow that is modal relative to its parent.
+	/// The parent window is dimmed and blocked from interaction until the modal is dismissed.
+	/// Supports stacking — each modal window becomes the host for the next.
+	/// </summary>
+	Window = 2,
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

Adds full nested modal stacking support and a new `MacOSModalPresentationStyle.Window` presentation style.

### Changes

**Core (`MacOSModalManager`)**
- **Sheet-on-sheet nesting**: each new sheet presents from the topmost existing sheet via `BeginSheet`, not always from the parent window
- **New `Window` style**: a floating child `NSWindow` that dims and blocks interaction on its parent. Uses `AddChildWindow` for positioning and a blocker overlay for input blocking.
- **Unified stacking**: renamed `SheetWindow` → `ModalWindow` and generalized `GetTopmostModalHost()` so all three styles (Sheet, Window, Overlay) share the same nesting infrastructure
- Any combination of styles can be stacked at any depth (sheet→window→sheet, window→window, etc.)

**API (`MacOSPage`)**
- Added `MacOSModalPresentationStyle.Window` enum value

**Samples**
- `ModalStackingPage` in ControlGallery (Features section)
- Stacking buttons added to SampleMac's `NavigationDemoPage` — each modal has push buttons for Sheet and Window so you can nest interactively