### PR TITLE
fix: Bridge MAUI layout invalidation to AppKit's NeedsLayout

### DIFF
--- a/samples/Sample/Pages/LayoutsPage.cs
+++ b/samples/Sample/Pages/LayoutsPage.cs
@@ -138,6 +138,9 @@ public class LayoutsPage : ContentPage
 						Content = new Label { Text = "Pill-style rounded", FontSize = 14, TextColor = Colors.White, HorizontalTextAlignment = TextAlignment.Center }
 					},
 
+					SectionHeader("Toggle Row Height"),
+					CreateToggleRowDemo(),
+
 					SectionHeader("Deeply Nested"),
 					new Border
 					{
@@ -176,6 +179,46 @@ public class LayoutsPage : ContentPage
 				}
 			}
 		};
+	}
+
+	static View CreateToggleRowDemo()
+	{
+		var collapsibleRow = new RowDefinition(new GridLength(0));
+
+		var grid = new Grid
+		{
+			HeightRequest = 200,
+			RowDefinitions = { new RowDefinition(GridLength.Star), collapsibleRow },
+			ColumnDefinitions = { new ColumnDefinition(GridLength.Star) },
+		};
+
+		var topBlock = ColorBlock("Always Visible (Row 0)", Colors.SteelBlue);
+		Grid.SetRow(topBlock, 0);
+		grid.Children.Add(topBlock);
+
+		var bottomBlock = ColorBlock("Toggled Row (Row 1)", Colors.Tomato);
+		Grid.SetRow(bottomBlock, 1);
+		grid.Children.Add(bottomBlock);
+
+		var toggle = new Button { Text = "Show Row 1" };
+		toggle.Clicked += (_, _) =>
+		{
+			var hidden = collapsibleRow.Height.Value is 0;
+			collapsibleRow.Height = hidden ? GridLength.Star : new GridLength(0);
+			toggle.Text = hidden ? "Hide Row 1" : "Show Row 1";
+		};
+
+		var wrapper = new VerticalStackLayout { Spacing = 8 };
+		wrapper.Children.Add(toggle);
+		wrapper.Children.Add(new Border
+		{
+			Stroke = Colors.SlateGray,
+			StrokeThickness = 1,
+			StrokeShape = new RoundRectangle { CornerRadius = 8 },
+			Padding = new Thickness(4),
+			Content = grid,
+		});
+		return wrapper;
 	}
 
 	static Label SectionHeader(string text) => new()

--- a/src/Platform.Maui.MacOS/Handlers/MacOSViewHandler.cs
+++ b/src/Platform.Maui.MacOS/Handlers/MacOSViewHandler.cs
@@ -51,6 +51,7 @@ public abstract class MacOSViewHandler<TVirtualView, TPlatformView> : ViewHandle
             if (ViewCommandMapper is CommandMapper<IView, IViewHandler> cmdMapper)
             {
                 cmdMapper[nameof(IView.Focus)] = MapFocus;
+                cmdMapper[nameof(IView.InvalidateMeasure)] = MapInvalidateMeasure;
             }
         }
         catch
@@ -471,6 +472,15 @@ public abstract class MacOSViewHandler<TVirtualView, TPlatformView> : ViewHandle
 
         var result = window.MakeFirstResponder(platformView);
         request.TrySetResult(result);
+    }
+
+    static void MapInvalidateMeasure(IViewHandler handler, IView view, object? args)
+    {
+        if (handler.PlatformView is NSView platformView)
+        {
+            platformView.InvalidateIntrinsicContentSize();
+            platformView.NeedsLayout = true;
+        }
     }
 
     public override void PlatformArrange(Rect rect)


### PR DESCRIPTION
When `RowDefinition.Height` (or similar layout properties) changed after initial layout, children kept their stale native frames. MAUI's `InvalidateMeasure` invokes a handler command, but the macOS backend had no mapping for it — so AppKit never set `NeedsLayout`, `Layout()` never fired, and `CrossPlatformArrange` never propagated new bounds to children.

Added an `InvalidateMeasure` command mapping in `MacOSViewHandler` that sets `NeedsLayout = true` and `InvalidateIntrinsicContentSize`. This is the AppKit equivalent of UIKit's `SetNeedsLayout` that every MAUI platform backend needs.

Also added a toggle-row demo to the sample LayoutsPage for manual verification.